### PR TITLE
Added multiple seeding options

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,11 @@
 Unreleased (dev branch)
 - Teams are now serialized by index, which means teams and bots can be edited after saving and loading a tournament. #2 #25 - NicEastvillage
 - The content on settings tabs are now centered and scales less weirdly. More ui changes are planned. #23 - NicEastvillage
+- Added seeding options. #10 - NicEastvillage
+    - Seed by order in participant list: Normal seeding
+    - No seeding: The teams are placed directly into the bracket/groups
+    - Random seeding: Shuffles the teams
+    - The swiss algorithm is currently unaffected as it doesn't consider seeding at all right now.
 
 
 Version 1.0.1 - 29. Dec 2018

--- a/src/dk/aau/cs/ds306e18/tournament/model/SeedingOption.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/SeedingOption.java
@@ -1,0 +1,18 @@
+package dk.aau.cs.ds306e18.tournament.model;
+
+public enum SeedingOption {
+    SEED_BY_ORDER("By order in list"),
+    NO_SEEDING("No seeding"),
+    RANDOM_SEEDING("Random seeding");
+
+    private String optionText;
+
+    SeedingOption(String optionText) {
+        this.optionText = optionText;
+    }
+
+    @Override
+    public String toString() {
+        return optionText;
+    }
+}

--- a/src/dk/aau/cs/ds306e18/tournament/model/Tournament.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/Tournament.java
@@ -31,6 +31,7 @@ public class Tournament {
     private ArrayList<Team> teams = new ArrayList<>();
     private ArrayList<Stage> stages = new ArrayList<>();
     private TieBreaker tieBreaker = new TieBreakerByGoalDiff();
+    private SeedingOption seedingOption = SeedingOption.SEED_BY_ORDER;
     private boolean started = false;
     private int currentStageIndex = -1;
 
@@ -169,6 +170,14 @@ public class Tournament {
         if (stages.size() < START_REQUIREMENT_STAGES) throw new IllegalStateException("There must be at least one stage in the tournament.");
         started = true;
         startNextStage();
+    }
+
+    public SeedingOption getSeedingOption() {
+        return seedingOption;
+    }
+
+    public void setSeedingOption(SeedingOption seedingOption) {
+        this.seedingOption = seedingOption;
     }
 
     public TieBreaker getTieBreaker() {

--- a/src/dk/aau/cs/ds306e18/tournament/model/Tournament.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/Tournament.java
@@ -7,11 +7,7 @@ import dk.aau.cs.ds306e18.tournament.rlbot.RLBotSettings;
 import dk.aau.cs.ds306e18.tournament.model.tiebreaker.TieBreaker;
 import dk.aau.cs.ds306e18.tournament.serialization.TrueTeamListAdapter;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 public class Tournament {
 
@@ -54,7 +50,6 @@ public class Tournament {
     public void addTeam(Team team) {
         if (started) throw new IllegalStateException("Tournament has already started.");
         teams.add(team);
-        sortTeamsAfterInitialSeed();
     }
 
     public void removeTeam(Team team) {
@@ -67,14 +62,23 @@ public class Tournament {
         teams.remove(index);
     }
 
-    public List<Team> getTeams() {
-        return new ArrayList<>(teams);
+    public void swapTeams(Team a, Team b) {
+        swapTeams(teams.indexOf(a), teams.indexOf(b));
     }
 
-    public void sortTeamsAfterInitialSeed() {
-        //TODO if (started) throw new IllegalStateException("Tournament has already started.");
-        // Sort teams by comparator and not data structure, since seed value is not final
-        teams.sort(Comparator.comparingInt(Team::getInitialSeedValue));
+    public void swapTeams(int a, int b) {
+        Collections.swap(teams, a, b);
+    }
+
+    /** Assigns initial seeds to the teams in the given list using their index in the given list */
+    public void assignInitialSeedValues(List<Team> teams) {
+        for (int i = 0; i < teams.size(); i++) {
+            teams.get(i).setInitialSeedValue(i + 1);
+        }
+    }
+
+    public List<Team> getTeams() {
+        return new ArrayList<>(teams);
     }
 
     public void addStage(Stage stage) {
@@ -141,19 +145,33 @@ public class Tournament {
 
         // State is ok
 
-        // Find best teams
-        List<Team> bestTeams;
+        // Find teams to transfer
+        List<Team> transferedTeams;
+        boolean seeding = seedingOption != SeedingOption.NO_SEEDING;
         if (currentStageIndex == -1) {
-            sortTeamsAfterInitialSeed();
-            bestTeams = new ArrayList<>(teams);
+
+            // This is the first stage, so all teams are transferred
+            transferedTeams = new ArrayList<>(teams);
+
+            // Random seeding. We shuffle the order and initial seeds, then tell the stage to use seeding
+            if (seedingOption == SeedingOption.RANDOM_SEEDING) {
+                Collections.shuffle(transferedTeams);
+            }
+
+            // Assign initial seeds based on this order
+            assignInitialSeedValues(transferedTeams);
+
         } else {
+
+            // Not the first stage, so we find the best teams of previous stage and use their order as seeding regardless of seeding option
             int wantedTeamCount = stages.get(currentStageIndex + 1).getNumberOfTeamsWanted();
-            bestTeams = getCurrentStage().getFormat().getTopTeams(wantedTeamCount, tieBreaker);
+            transferedTeams = getCurrentStage().getFormat().getTopTeams(wantedTeamCount, tieBreaker);
+            seeding = true;
         }
 
         // Proceed to next stage
         currentStageIndex++;
-        getCurrentStage().getFormat().start(bestTeams);
+        getCurrentStage().getFormat().start(transferedTeams, seeding);
     }
 
     public boolean hasStarted() {

--- a/src/dk/aau/cs/ds306e18/tournament/model/format/Format.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/format/Format.java
@@ -2,7 +2,6 @@ package dk.aau.cs.ds306e18.tournament.model.format;
 
 import dk.aau.cs.ds306e18.tournament.model.Team;
 import dk.aau.cs.ds306e18.tournament.model.match.Match;
-import dk.aau.cs.ds306e18.tournament.model.match.MatchChangeListener;
 import dk.aau.cs.ds306e18.tournament.model.tiebreaker.TieBreaker;
 import dk.aau.cs.ds306e18.tournament.ui.bracketObjects.ModelCoupledUI;
 import dk.aau.cs.ds306e18.tournament.ui.BracketOverviewTabController;
@@ -16,7 +15,7 @@ public interface Format {
     /**
      * Starts the stage with the given list of teams. The teams should seeded after the order in the list.
      */
-    void start(List<Team> seededTeams);
+    void start(List<Team> seededTeams, boolean doSeeding);
 
     /**
      * Returns the status of the format.

--- a/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinFormat.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinFormat.java
@@ -24,7 +24,7 @@ public class RoundRobinFormat extends GroupFormat implements MatchPlayedListener
 
     /** Constructor that automatically creates an arraylist of matches made on the principles of berger tables.
      * @param seededTeams arraylist of all the teams in the bracket.
-     * @param doSeeding*/
+     * @param doSeeding whether or not to group teams based on their seed. */
     public void start(List<Team> seededTeams, boolean doSeeding) {
         teams = new ArrayList<>(seededTeams);
         ArrayList<Team> teams = new ArrayList<>(seededTeams);
@@ -90,9 +90,10 @@ public class RoundRobinFormat extends GroupFormat implements MatchPlayedListener
             for (int i = 0; i < numberOfGroups; i++) {
 
                 // Some groups may be bigger if team count is not divisible by number of groups
+                // The first group(s) will be the small ones
                 int size = groupSize;
                 if (i >= numberOfGroups - leftoverTeams) {
-                    groupSize++;
+                    size++;
                 }
 
                 RoundRobinGroup group = new RoundRobinGroup(teams.subList(t, t + size));

--- a/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinFormat.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinFormat.java
@@ -3,7 +3,6 @@ package dk.aau.cs.ds306e18.tournament.model.format;
 import dk.aau.cs.ds306e18.tournament.model.GroupFormat;
 import dk.aau.cs.ds306e18.tournament.model.Team;
 import dk.aau.cs.ds306e18.tournament.model.match.Match;
-import dk.aau.cs.ds306e18.tournament.model.match.MatchChangeListener;
 import dk.aau.cs.ds306e18.tournament.model.match.MatchPlayedListener;
 import dk.aau.cs.ds306e18.tournament.ui.bracketObjects.RoundRobinNode;
 import dk.aau.cs.ds306e18.tournament.ui.bracketObjects.RoundRobinSettingsNode;
@@ -17,15 +16,16 @@ public class RoundRobinFormat extends GroupFormat implements MatchPlayedListener
     private static final Team DUMMY_TEAM = new Team("Dummy", new ArrayList<>(), 0, "Dummy team description");
 
     private ArrayList<Match> matches;
-    private ArrayList<RoundRobinGroup> groups = new ArrayList<>();
+    private ArrayList<RoundRobinGroup> groups;
     //should be set before start() is called, to determine number of groups that should be created
     private int numberOfGroups = 1;
 
     transient private List<StageStatusChangeListener> statusChangeListeners = new LinkedList<>();
 
     /** Constructor that automatically creates an arraylist of matches made on the principles of berger tables.
-     * @param seededTeams arraylist of all the teams in the bracket. */
-    public void start(List<Team> seededTeams) {
+     * @param seededTeams arraylist of all the teams in the bracket.
+     * @param doSeeding*/
+    public void start(List<Team> seededTeams, boolean doSeeding) {
         teams = new ArrayList<>(seededTeams);
         ArrayList<Team> teams = new ArrayList<>(seededTeams);
 
@@ -39,7 +39,7 @@ public class RoundRobinFormat extends GroupFormat implements MatchPlayedListener
             }
 
             status = StageStatus.RUNNING;
-            createGroupsWithMatches(teams);
+            createGroupsAndMatches(teams, doSeeding);
             matches = extractMatchesFromGroups();
         }
     }
@@ -55,51 +55,69 @@ public class RoundRobinFormat extends GroupFormat implements MatchPlayedListener
         } else return false;
     }
 
-    /**
-     * this function takes the teams input array, which is the list of all teams, and split this into sub arrays, and
-     * creates groups with matches based on these. These groups are added to the groups list in class.
-     */
-    private void createGroupsWithMatches(ArrayList<Team> teams) {
+    /** This function populates the groups list and generates the matches for each group. */
+    private void createGroupsAndMatches(ArrayList<Team> teams, boolean doSeeding) {
+        groups = new ArrayList<>();
+
+        int groupSize = teams.size() / numberOfGroups;
         int leftoverTeams = teams.size() % numberOfGroups;
 
-        for (int i = 0; i < numberOfGroups; i++) {
-            ArrayList<Team> splitArray = pickTeamsForGroup(teams, i);
+        if (doSeeding) {
 
-            //if there must be groups with more teams than others, add an extra team to the first groups, from the highest
-            //index of the teams array
-            if (leftoverTeams != 0) {
-                splitArray.add(teams.get(teams.size() - leftoverTeams));
-                leftoverTeams--;
+            // Pick teams evenly
+            for (int i = 0; i < numberOfGroups; i++) {
+
+                // Pick every numberOfGroups'th team
+                ArrayList<Team> teamsForGroup = new ArrayList<>();
+                for (int j = 0; j < groupSize; j++) {
+                    teamsForGroup.add(teams.get(i + j * numberOfGroups));
+                }
+
+                // When team count is not divisible by group count, the leftover teams are added to the lowest seeded groups
+                if (i >= numberOfGroups - leftoverTeams) {
+                    teamsForGroup.add(teams.get(teams.size() - numberOfGroups + i));
+                }
+
+                RoundRobinGroup group = new RoundRobinGroup(teamsForGroup);
+                group.setRounds(generateMatches(group.getTeams()));
+                groups.add(group);
             }
 
-            //if there is an uneven amount of teams in the group, add a dummy team and later remove matches that include the dummy team
-            if (splitArray.size() % 2 != 0) {
-                splitArray.add(DUMMY_TEAM);
-            }
+        } else {
 
-            RoundRobinGroup roundRobinGroup = new RoundRobinGroup(splitArray);
-            roundRobinGroup.setRounds(generateMatches(roundRobinGroup.getTeams()));
-            groups.add(roundRobinGroup);
+            // Pick clusters of teams
+            int t = 0;
+            for (int i = 0; i < numberOfGroups; i++) {
+
+                // Some groups may be bigger if team count is not divisible by number of groups
+                int size = groupSize;
+                if (i >= numberOfGroups - leftoverTeams) {
+                    groupSize++;
+                }
+
+                RoundRobinGroup group = new RoundRobinGroup(teams.subList(t, t + size));
+                group.setRounds(generateMatches(group.getTeams()));
+                groups.add(group);
+
+                t += size;
+            }
         }
     }
 
-    /** @return a list that contains each n'th (numberOfGroups) team. */
-    private ArrayList<Team> pickTeamsForGroup(ArrayList<Team> teams, int startingPoint) {
-        ArrayList<Team> splitArray = new ArrayList<>();
+    /**
+     * Creates all matches with each team changing color between each of their matches, algorithm based on berger tables.
+     * @return an list of list of matches with the given teams. Each nested list is a round of matches.
+     */
+    private ArrayList<ArrayList<Match>> generateMatches(ArrayList<Team> t) {
+        // Add dummy team if team count is odd - berger tables only work for an even number.
+        // The matches with dummy teams are removed later
+        ArrayList<Team> teams = new ArrayList<>(t);
+        if (t.size() % 2 != 0) {
+            teams.add(DUMMY_TEAM);
+        }
 
-        int pickCount = teams.size() / numberOfGroups;
-        for (int i = 0; i < pickCount; i++)
-            splitArray.add(teams.get(startingPoint + numberOfGroups * i));
-        return splitArray;
-    }
-
-    /** Creates all matches with each team changing color between each of their matches, algorithm based on
-     * berger tables.
-     * @param teams arraylist of all teams in the bracket.
-     * @return an arrayList, which represents rounds, of arrayLists with matches. */
-    private ArrayList<ArrayList<Match>> generateMatches(ArrayList<Team> teams) {
         int nextBlue, nextOrange;
-        Match[][] tempMatches = new Match[teams.size() - 1][teams.size() / 2];
+        Match[][] table = new Match[teams.size() - 1][teams.size() / 2];
 
         HashMap<Team, Integer> map = createIdHashMap(teams);
 
@@ -109,7 +127,7 @@ public class RoundRobinFormat extends GroupFormat implements MatchPlayedListener
             for (int match = 0; match < teams.size() / 2; match++) {
                 //create first round, which is not based on previous rounds
                 if (round == 0) {
-                    tempMatches[round][match] = createNewMatch(teams.get(match), teams.get(teams.size() - (match + 1)));
+                    table[round][match] = createNewMatch(teams.get(match), teams.get(teams.size() - (match + 1)));
                 }
                 //hardcoding team with highest id (numberOfTeams - 1 ) to first match each round
                 //the other team is found by berger tables rules (findIdOfNextPlayer) on the id of the team in the same match,
@@ -117,24 +135,36 @@ public class RoundRobinFormat extends GroupFormat implements MatchPlayedListener
                 else if (match == 0) {
                     //else become orange team
                     if ((round % 2) == 0) {
-                        nextBlue = findIdOfNextPlayer(map.get(tempMatches[round - 1][match].getOrangeTeam()), teams.size());
-                        tempMatches[round][match] = createNewMatch(teams.get(nextBlue - 1), (teams.get(teams.size() - 1)));
+                        nextBlue = findIdOfNextPlayer(map.get(table[round - 1][match].getOrangeTeam()), teams.size());
+                        table[round][match] = createNewMatch(teams.get(nextBlue - 1), (teams.get(teams.size() - 1)));
                         //if uneven round, player with highest id becomes blue player
                     } else {
-                        nextOrange = findIdOfNextPlayer(map.get(tempMatches[round - 1][match].getBlueTeam()), teams.size());
-                        tempMatches[round][match] = createNewMatch((teams.get(teams.size() - 1)), teams.get(nextOrange - 1));
+                        nextOrange = findIdOfNextPlayer(map.get(table[round - 1][match].getBlueTeam()), teams.size());
+                        table[round][match] = createNewMatch((teams.get(teams.size() - 1)), teams.get(nextOrange - 1));
                     }
                 } else {
                     //if not the first round, or first match, find both players by findIdOfNextPlayer according to berger tables,
                     //on previous teams
-                    nextBlue = findIdOfNextPlayer(map.get(tempMatches[round - 1][match].getBlueTeam()), teams.size());
-                    nextOrange = findIdOfNextPlayer(map.get(tempMatches[round - 1][match].getOrangeTeam()), teams.size());
-                    tempMatches[round][match] = createNewMatch(teams.get(nextBlue - 1), (teams.get(nextOrange - 1)));
+                    nextBlue = findIdOfNextPlayer(map.get(table[round - 1][match].getBlueTeam()), teams.size());
+                    nextOrange = findIdOfNextPlayer(map.get(table[round - 1][match].getOrangeTeam()), teams.size());
+                    table[round][match] = createNewMatch(teams.get(nextBlue - 1), (teams.get(nextOrange - 1)));
                 }
             }
         }
 
-        return removeDummyMatches(tempMatches);
+        // Find matches that does not contain the dummy team
+        ArrayList<ArrayList<Match>> matches = new ArrayList<>();
+        for (int i = 0; i < table.length; i++) {
+            matches.add(new ArrayList<>());
+            for (int j = 0; j < table[i].length; j++) {
+                if (!table[i][j].getOrangeTeam().equals(DUMMY_TEAM) &&
+                        !table[i][j].getBlueTeam().equals(DUMMY_TEAM)) {
+                    matches.get(i).add(table[i][j]);
+                }
+            }
+        }
+
+        return matches;
     }
 
     /**
@@ -174,29 +204,6 @@ public class RoundRobinFormat extends GroupFormat implements MatchPlayedListener
             return id - ((limit / 2) - 1);
         } else return id + (limit / 2);
     }
-
-    /** @return the given arrayList with dummy teams removed. */
-    private ArrayList<ArrayList<Match>> removeDummyMatches(Match[][] tempMatches) {
-
-        ArrayList<ArrayList<Match>> matches = new ArrayList<>();
-
-
-        for (int i = 0; i < tempMatches.length; i++) {
-            matches.add(new ArrayList<>());
-            for (int j = 0; j < tempMatches[i].length; j++) {
-                if (tempMatches[i][j].getOrangeTeam().equals(DUMMY_TEAM) ||
-                        tempMatches[i][j].getBlueTeam().equals(DUMMY_TEAM)) {
-                    continue;
-                } else {
-                    matches.get(i).add(tempMatches[i][j]);
-                    //matches.add(tempMatches[i][j]);
-                }
-            }
-        }
-
-        return matches;
-    }
-
 
     /**
      * @return a list of all matches contained in the Round Robin Groups

--- a/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinGroup.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinGroup.java
@@ -4,6 +4,7 @@ import dk.aau.cs.ds306e18.tournament.model.Team;
 import dk.aau.cs.ds306e18.tournament.model.match.Match;
 
 import java.util.ArrayList;
+import java.util.List;
 
 
 public class RoundRobinGroup {
@@ -11,8 +12,8 @@ public class RoundRobinGroup {
     private ArrayList<Team> teams;
     private ArrayList<ArrayList<Match>> rounds;
 
-    public RoundRobinGroup(ArrayList<Team> seededTeams) {
-        this.teams = new ArrayList<>(seededTeams);
+    public RoundRobinGroup(List<Team> teams) {
+        this.teams = new ArrayList<>(teams);
     }
 
     public void setRounds(ArrayList<ArrayList<Match>> round){

--- a/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinGroup.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinGroup.java
@@ -24,16 +24,6 @@ public class RoundRobinGroup {
         return teams;
     }
 
-    public ArrayList<Team> getTeamsWithoutDummy() {
-        ArrayList<Team> teams = new ArrayList<>();
-        for (Team team: this.teams) {
-            if (team.equals(RoundRobinFormat.getDummyTeam())) {
-                continue;
-            } else teams.add(team);
-        }
-        return teams;
-    }
-
     public ArrayList<Match> getMatches(){
 
         ArrayList<Match> matches = new ArrayList<>();

--- a/src/dk/aau/cs/ds306e18/tournament/model/format/SingleEliminationFormat.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/format/SingleEliminationFormat.java
@@ -23,11 +23,11 @@ public class SingleEliminationFormat implements Format, MatchPlayedListener {
     transient private List<StageStatusChangeListener> statusChangeListeners = new LinkedList<>();
 
     @Override
-    public void start(List<Team> seededTeams) {
+    public void start(List<Team> seededTeams, boolean doSeeding) {
         this.seededTeams = new ArrayList<>(seededTeams);
         rounds = (int) Math.ceil(Math.log(seededTeams.size()) / Math.log(2));
         generateBracket();
-        seedBracket(seededTeams);
+        seedBracket(seededTeams, doSeeding);
         status = StageStatus.RUNNING;
         finalMatch.registerMatchPlayedListener(this);
     }
@@ -56,16 +56,19 @@ public class SingleEliminationFormat implements Format, MatchPlayedListener {
 
     /** Seeds the single-elimination bracket with teams to give better placements.
      * If there are an insufficient amount of teams, the team(s) with the best seeding(s) will be placed in the next round instead.
-     * @param seededTeams a list containing the teams in the tournament */
-    private void seedBracket(List<Team> seededTeams) {
+     * @param seededTeams a list containing the teams in the tournament
+     * @param doSeeding whether or not to use seeding. If false, the reordering of teams is skipped. */
+    private void seedBracket(List<Team> seededTeams, boolean doSeeding) {
         ArrayList<Team> seedList = new ArrayList<>(seededTeams);
 
         //Create needed amount of byes to match with the empty matches
         ArrayList<Team> byeList = addByes(seededTeams.size());
         seedList.addAll(byeList);
 
-        //Reorders list with fair seeding method
-        fairSeeding(seedList);
+        if (doSeeding) {
+            //Reorders list with fair seeding method
+            fairSeeding(seedList);
+        }
 
         //Places the teams in the bracket, and removes unnecessary matches
         placeTeamsInBracket(seedList, byeList);

--- a/src/dk/aau/cs/ds306e18/tournament/model/format/SwissFormat.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/format/SwissFormat.java
@@ -23,7 +23,7 @@ public class SwissFormat extends GroupFormat implements MatchChangeListener, Mat
     transient private List<StageStatusChangeListener> statusChangeListeners = new LinkedList<>();
 
     @Override
-    public void start(List<Team> teams) {
+    public void start(List<Team> teams, boolean doSeeding) {
         rounds = new ArrayList<>();
         maxRoundsPossible = getMaxRoundsPossible(teams.size());
         roundCount = maxRoundsPossible < roundCount ? maxRoundsPossible : roundCount;
@@ -133,9 +133,10 @@ public class SwissFormat extends GroupFormat implements MatchChangeListener, Mat
      */
     private void createNextRound() {
 
+        // TODO Consider seeding for first round
+
         // Create ordered list of team, based on points.
         ArrayList<Team> orderedTeamList = getOrderedTeamsListFromPoints(teams, teamPoints);
-
         ArrayList<Match> createdMatches = new ArrayList<>();
 
         // Create matches while there is more than 1 team in the list.

--- a/src/dk/aau/cs/ds306e18/tournament/ui/ParticipantSettingsTabController.java
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/ParticipantSettingsTabController.java
@@ -2,8 +2,11 @@ package dk.aau.cs.ds306e18.tournament.ui;
 
 import com.google.common.base.CharMatcher;
 import dk.aau.cs.ds306e18.tournament.model.Bot;
+import dk.aau.cs.ds306e18.tournament.model.SeedingOption;
 import dk.aau.cs.ds306e18.tournament.model.Team;
 import dk.aau.cs.ds306e18.tournament.model.Tournament;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
@@ -29,6 +32,7 @@ public class ParticipantSettingsTabController {
     private static final String CLIPBOARD_EMPTY_STRING = "<empty>";
 
     @FXML private GridPane participantSettingsTab;
+    @FXML private ChoiceBox<SeedingOption> seedingChoicebox;
     @FXML private TextField teamNameTextField;
     @FXML private TextField botNameTextField;
     @FXML private TextField developerTextField;
@@ -55,18 +59,23 @@ public class ParticipantSettingsTabController {
     @FXML
     private void initialize() {
 
+        // Seeding Option
+        seedingChoicebox.setItems(FXCollections.observableArrayList(SeedingOption.values()));
+        seedingChoicebox.getSelectionModel().select(Tournament.get().getSeedingOption());
+        seedingChoicebox.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> Tournament.get().setSeedingOption(newValue));
+
         setUpTeamsListView();
 
-        //Sets the VBox for team and bot as false, hiding them
+        // Sets the VBox for team and bot as false, hiding them
         botSettingsVbox.setVisible(false);
         teamSettingsVbox.setVisible(false);
         configPathTextField.setEditable(false);
 
-        //By default the remove team and bot button is disabled
+        // By default the remove team and bot button is disabled
         removeTeamBtn.setDisable(true);
         removeBotBtn.setDisable(true);
 
-        //Adds selectionslistener to bot ListView
+        // Adds selectionslistener to bot ListView
         botsListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
             updateBotFields();
             updateAddRemoveButtonsEnabling();

--- a/src/dk/aau/cs/ds306e18/tournament/ui/ParticipantSettingsTabController.java
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/ParticipantSettingsTabController.java
@@ -350,26 +350,15 @@ public class ParticipantSettingsTabController {
     /** Swaps a team upwards in the list of teams. Used to allow ordering of Team and thereby their seed. */
     @FXML
     private void swapTeamUpwards() {
-        swapTeamSeeds(Tournament.get().getTeams().get(getSelectedTeamIndex()),
-                Tournament.get().getTeams().get(getSelectedTeamIndex() - 1));
+        Tournament.get().swapTeams(getSelectedTeamIndex(), getSelectedTeamIndex() - 1);
+        teamsListView.setItems(FXCollections.observableArrayList(Tournament.get().getTeams()));
+        teamsListView.refresh();
     }
 
     /** Swaps a team downwards in the list of teams. Used to allow ordering of Team and thereby their seed. */
     @FXML
     private void swapTeamDownwards() {
-        swapTeamSeeds(Tournament.get().getTeams().get(getSelectedTeamIndex()),
-                Tournament.get().getTeams().get(getSelectedTeamIndex() + 1));
-    }
-
-    /** Swaps seeds of the firsts given team with the second team. */
-    private void swapTeamSeeds(Team first, Team second){
-
-        int firstSeed = first.getInitialSeedValue();
-        first.setInitialSeedValue(second.getInitialSeedValue());
-        second.setInitialSeedValue(firstSeed);
-
-        Tournament.get().sortTeamsAfterInitialSeed();
-
+        Tournament.get().swapTeams(getSelectedTeamIndex(), getSelectedTeamIndex() + 1);
         teamsListView.setItems(FXCollections.observableArrayList(Tournament.get().getTeams()));
         teamsListView.refresh();
     }

--- a/src/dk/aau/cs/ds306e18/tournament/ui/layout/ParticipantSettingsTab.fxml
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/layout/ParticipantSettingsTab.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.control.TextArea?>
@@ -14,7 +15,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<GridPane id="PS-mainGrid" fx:id="participantSettingsTab" prefHeight="572.0" prefWidth="800.0" stylesheets="@css/stylesheet.css" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="dk.aau.cs.ds306e18.tournament.ui.ParticipantSettingsTabController">
+<GridPane id="PS-mainGrid" fx:id="participantSettingsTab" prefHeight="572.0" prefWidth="800.0" stylesheets="@css/stylesheet.css" xmlns="http://javafx.com/javafx/1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dk.aau.cs.ds306e18.tournament.ui.ParticipantSettingsTabController">
   <columnConstraints>
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
@@ -34,7 +35,24 @@
                   <Insets top="15.0" />
                </VBox.margin>
             </Text>
-            <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Teams (sort by seeding)">
+            <GridPane>
+               <columnConstraints>
+                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+                  <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" minWidth="10.0" />
+               </columnConstraints>
+               <rowConstraints>
+                  <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+               </rowConstraints>
+               <children>
+                  <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Seeding:">
+                     <font>
+                        <Font size="16.0" />
+                     </font>
+                  </Text>
+                  <ChoiceBox fx:id="seedingChoicebox" prefHeight="27.0" prefWidth="130.0" GridPane.columnIndex="1" />
+               </children>
+            </GridPane>
+            <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Teams">
                <font>
                   <Font size="16.0" />
                </font>

--- a/test/dk/aau/cs/ds306e18/tournament/model/RoundRobinFormatTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/RoundRobinFormatTest.java
@@ -24,7 +24,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(bracket.getStatus(), StageStatus.RUNNING);
     }
@@ -36,7 +36,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(bracket.getStatus(), StageStatus.RUNNING);
     }
@@ -48,7 +48,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(bracket.getStatus(), StageStatus.RUNNING);
     }
@@ -60,7 +60,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
     }
 
     @Test
@@ -70,7 +70,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals((bracket.findIdOfNextPlayer(3,numberOfTeams)), 13);
         assertEquals((bracket.findIdOfNextPlayer(1,numberOfTeams)), 11);
@@ -91,7 +91,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(numberOfMatchesInRoundRobin(numberOfTeams), bracket.getUpcomingMatches().size());
     }
@@ -103,7 +103,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(numberOfMatchesInRoundRobin(numberOfTeams), bracket.getUpcomingMatches().size());
     }
@@ -115,7 +115,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(numberOfMatchesInRoundRobin(numberOfTeams), bracket.getUpcomingMatches().size());
     }
@@ -127,7 +127,7 @@ public class RoundRobinFormatTest {
         int teamSize = 0;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(0, bracket.getUpcomingMatches().size());
     }
@@ -139,7 +139,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(0, bracket.getCompletedMatches().size());
     }
@@ -151,7 +151,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         setAllUpcommingMatchesPlayed(bracket);
 
@@ -165,7 +165,7 @@ public class RoundRobinFormatTest {
         int teamSize = 2;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(numberOfMatchesInRoundRobin(numberOfTeams), bracket.getAllMatches().size());
     }
@@ -177,7 +177,7 @@ public class RoundRobinFormatTest {
         int teamSize = 2;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(0, bracket.getAllMatches().size());
     }
@@ -189,7 +189,7 @@ public class RoundRobinFormatTest {
         int teamSize = 2;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(0, bracket.getPendingMatches().size());
     }
@@ -198,7 +198,7 @@ public class RoundRobinFormatTest {
     public void getTopTeams01() { //No teams
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(new ArrayList<Team>());
+        bracket.start(new ArrayList<Team>(), seeding);
 
         assertEquals(0, bracket.getTopTeams(10, new TieBreakerBySeed()).size());
     }
@@ -208,7 +208,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         ArrayList<Team> inputTeams = generateSeededTeams(4, 2);
-        bracket.start(inputTeams);
+        bracket.start(inputTeams, seeding);
 
         setAllUpcommingMatchesPlayed(bracket);
         //All teams now have the same amount of points.
@@ -244,7 +244,7 @@ public class RoundRobinFormatTest {
     public void getStatus02() { //Running
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(4, 2));
+        bracket.start(generateTeams(4, 2), seeding);
 
         assertEquals(StageStatus.RUNNING, bracket.getStatus());
     }
@@ -254,7 +254,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
 
-        bracket.start(generateTeams(2, 2));
+        bracket.start(generateTeams(2, 2), seeding);
 
         //Set all matches to played
         setAllUpcommingMatchesPlayed(bracket);
@@ -267,7 +267,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(2);
-        bracket.start(generateTeams(12,2));
+        bracket.start(generateTeams(12,2), seeding);
 
 
         assertEquals(2,bracket.getGroups().size());
@@ -292,7 +292,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(2);
-        bracket.start(generateTeams(10,2));
+        bracket.start(generateTeams(10,2), seeding);
 
         assertEquals(2,bracket.getGroups().size());
         for (RoundRobinGroup group: bracket.getGroups()) {
@@ -315,7 +315,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(3);
-        bracket.start(generateTeams(18,2));
+        bracket.start(generateTeams(18,2), seeding);
 
         assertEquals(3,bracket.getGroups().size());
         for (RoundRobinGroup group: bracket.getGroups()) {
@@ -338,7 +338,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(3);
-        bracket.start(generateTeams(10,2));
+        bracket.start(generateTeams(10,2), seeding);
 
         assertEquals(3,bracket.getGroups().size());
         for (RoundRobinGroup group: bracket.getGroups()) {
@@ -371,7 +371,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(20);
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(5, bracket.getGroups().size());
     }
@@ -385,7 +385,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(0);
-        bracket.start(generateTeams(numberOfTeams, teamSize));
+        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(1, bracket.getGroups().size());
     }
@@ -398,7 +398,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(numberOfGroups);
-        bracket.start(generateTeams(numberOfTeams, 2));
+        bracket.start(generateTeams(numberOfTeams, 2), seeding);
 
         ArrayList<RoundRobinGroup> groups = bracket.getGroups();
 
@@ -419,7 +419,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(numberOfGroups);
-        bracket.start(generateTeams(numberOfTeams, 2));
+        bracket.start(generateTeams(numberOfTeams, 2), seeding);
 
         ArrayList<RoundRobinGroup> groups = bracket.getGroups();
 

--- a/test/dk/aau/cs/ds306e18/tournament/model/RoundRobinFormatTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/RoundRobinFormatTest.java
@@ -153,7 +153,7 @@ public class RoundRobinFormatTest {
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
-        setAllUpcommingMatchesPlayed(bracket);
+        setAllUpcomingMatchesPlayed(bracket);
 
         assertEquals(numberOfMatchesInRoundRobin(numberOfTeams), bracket.getCompletedMatches().size());
     }
@@ -210,7 +210,7 @@ public class RoundRobinFormatTest {
         ArrayList<Team> inputTeams = generateSeededTeams(4, 2);
         bracket.start(inputTeams, true);
 
-        setAllUpcommingMatchesPlayed(bracket);
+        setAllUpcomingMatchesPlayed(bracket);
         //All teams now have the same amount of points.
 
         ArrayList<Team> top3Teams = new ArrayList<>(bracket.getTopTeams(3, new TieBreakerBySeed()));
@@ -257,7 +257,7 @@ public class RoundRobinFormatTest {
         bracket.start(generateTeams(2, 2), true);
 
         //Set all matches to played
-        setAllUpcommingMatchesPlayed(bracket);
+        setAllUpcomingMatchesPlayed(bracket);
 
         assertEquals(StageStatus.CONCLUDED, bracket.getStatus());
     }
@@ -427,10 +427,91 @@ public class RoundRobinFormatTest {
         }
     }
 
+    @Test
+    public void withSeeding01() {
+        int numberOfTeams = 6;
+        ArrayList<Team> teams = generateTeams(numberOfTeams, 1);
+
+        RoundRobinFormat roundrobin = new RoundRobinFormat();
+        roundrobin.setNumberOfGroups(2);
+        roundrobin.start(teams, true);
+
+        assertSame(teams.get(0), roundrobin.getGroups().get(0).getTeams().get(0));
+        assertSame(teams.get(2), roundrobin.getGroups().get(0).getTeams().get(1));
+        assertSame(teams.get(4), roundrobin.getGroups().get(0).getTeams().get(2));
+        assertSame(teams.get(1), roundrobin.getGroups().get(1).getTeams().get(0));
+        assertSame(teams.get(3), roundrobin.getGroups().get(1).getTeams().get(1));
+        assertSame(teams.get(5), roundrobin.getGroups().get(1).getTeams().get(2));
+    }
+
+    @Test
+    public void withSeeding02() {
+        // with seeding and number of teams is not divisible by group count
+
+        int numberOfTeams = 8;
+        ArrayList<Team> teams = generateTeams(numberOfTeams, 1);
+
+        RoundRobinFormat roundrobin = new RoundRobinFormat();
+        roundrobin.setNumberOfGroups(3);
+        roundrobin.start(teams, true);
+
+        // Group 1 is seed 1 and 4
+        assertSame(teams.get(0), roundrobin.getGroups().get(0).getTeams().get(0));
+        assertSame(teams.get(3), roundrobin.getGroups().get(0).getTeams().get(1));
+        // Group 2 is seed 2, 5, and 7
+        assertSame(teams.get(1), roundrobin.getGroups().get(1).getTeams().get(0));
+        assertSame(teams.get(4), roundrobin.getGroups().get(1).getTeams().get(1));
+        assertSame(teams.get(6), roundrobin.getGroups().get(1).getTeams().get(2));
+        // Group 3 is seed 3, 6, and 8
+        assertSame(teams.get(2), roundrobin.getGroups().get(2).getTeams().get(0));
+        assertSame(teams.get(5), roundrobin.getGroups().get(2).getTeams().get(1));
+        assertSame(teams.get(7), roundrobin.getGroups().get(2).getTeams().get(2));
+    }
+
+    @Test
+    public void withoutSeeding01() {
+        int numberOfTeams = 6;
+        ArrayList<Team> teams = generateTeams(numberOfTeams, 1);
+
+        RoundRobinFormat roundrobin = new RoundRobinFormat();
+        roundrobin.setNumberOfGroups(2);
+        roundrobin.start(teams, false);
+
+        assertSame(teams.get(0), roundrobin.getGroups().get(0).getTeams().get(0));
+        assertSame(teams.get(1), roundrobin.getGroups().get(0).getTeams().get(1));
+        assertSame(teams.get(2), roundrobin.getGroups().get(0).getTeams().get(2));
+        assertSame(teams.get(3), roundrobin.getGroups().get(1).getTeams().get(0));
+        assertSame(teams.get(4), roundrobin.getGroups().get(1).getTeams().get(1));
+        assertSame(teams.get(5), roundrobin.getGroups().get(1).getTeams().get(2));
+    }
+
+    @Test
+    public void withoutSeeding02() {
+        // without seeding and number of teams is not divisible by group count
+
+        int numberOfTeams = 8;
+        ArrayList<Team> teams = generateTeams(numberOfTeams, 1);
+
+        RoundRobinFormat roundrobin = new RoundRobinFormat();
+        roundrobin.setNumberOfGroups(3);
+        roundrobin.start(teams, false);
+
+        assertSame(teams.get(0), roundrobin.getGroups().get(0).getTeams().get(0));
+        assertSame(teams.get(1), roundrobin.getGroups().get(0).getTeams().get(1));
+
+        assertSame(teams.get(2), roundrobin.getGroups().get(1).getTeams().get(0));
+        assertSame(teams.get(3), roundrobin.getGroups().get(1).getTeams().get(1));
+        assertSame(teams.get(4), roundrobin.getGroups().get(1).getTeams().get(2));
+
+        assertSame(teams.get(5), roundrobin.getGroups().get(2).getTeams().get(0));
+        assertSame(teams.get(6), roundrobin.getGroups().get(2).getTeams().get(1));
+        assertSame(teams.get(7), roundrobin.getGroups().get(2).getTeams().get(2));
+    }
+
     /**
      * sets all upcoming matches in the given format to have been played. The best seeded team wins.
      */
-    private void setAllUpcommingMatchesPlayed(GroupFormat format) {
+    private void setAllUpcomingMatchesPlayed(GroupFormat format) {
 
         //Set all matches to played
         List<Match> matches = format.getUpcomingMatches();

--- a/test/dk/aau/cs/ds306e18/tournament/model/RoundRobinFormatTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/RoundRobinFormatTest.java
@@ -24,7 +24,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(bracket.getStatus(), StageStatus.RUNNING);
     }
@@ -36,7 +36,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(bracket.getStatus(), StageStatus.RUNNING);
     }
@@ -48,7 +48,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(bracket.getStatus(), StageStatus.RUNNING);
     }
@@ -60,7 +60,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
     }
 
     @Test
@@ -70,7 +70,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals((bracket.findIdOfNextPlayer(3,numberOfTeams)), 13);
         assertEquals((bracket.findIdOfNextPlayer(1,numberOfTeams)), 11);
@@ -91,7 +91,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(numberOfMatchesInRoundRobin(numberOfTeams), bracket.getUpcomingMatches().size());
     }
@@ -103,7 +103,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(numberOfMatchesInRoundRobin(numberOfTeams), bracket.getUpcomingMatches().size());
     }
@@ -115,7 +115,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(numberOfMatchesInRoundRobin(numberOfTeams), bracket.getUpcomingMatches().size());
     }
@@ -127,7 +127,7 @@ public class RoundRobinFormatTest {
         int teamSize = 0;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(0, bracket.getUpcomingMatches().size());
     }
@@ -139,7 +139,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(0, bracket.getCompletedMatches().size());
     }
@@ -151,7 +151,7 @@ public class RoundRobinFormatTest {
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         setAllUpcommingMatchesPlayed(bracket);
 
@@ -165,7 +165,7 @@ public class RoundRobinFormatTest {
         int teamSize = 2;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(numberOfMatchesInRoundRobin(numberOfTeams), bracket.getAllMatches().size());
     }
@@ -177,7 +177,7 @@ public class RoundRobinFormatTest {
         int teamSize = 2;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(0, bracket.getAllMatches().size());
     }
@@ -189,7 +189,7 @@ public class RoundRobinFormatTest {
         int teamSize = 2;
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(0, bracket.getPendingMatches().size());
     }
@@ -198,7 +198,7 @@ public class RoundRobinFormatTest {
     public void getTopTeams01() { //No teams
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(new ArrayList<Team>(), seeding);
+        bracket.start(new ArrayList<Team>(), true);
 
         assertEquals(0, bracket.getTopTeams(10, new TieBreakerBySeed()).size());
     }
@@ -208,7 +208,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         ArrayList<Team> inputTeams = generateSeededTeams(4, 2);
-        bracket.start(inputTeams, seeding);
+        bracket.start(inputTeams, true);
 
         setAllUpcommingMatchesPlayed(bracket);
         //All teams now have the same amount of points.
@@ -244,7 +244,7 @@ public class RoundRobinFormatTest {
     public void getStatus02() { //Running
 
         RoundRobinFormat bracket = new RoundRobinFormat();
-        bracket.start(generateTeams(4, 2), seeding);
+        bracket.start(generateTeams(4, 2), true);
 
         assertEquals(StageStatus.RUNNING, bracket.getStatus());
     }
@@ -254,7 +254,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
 
-        bracket.start(generateTeams(2, 2), seeding);
+        bracket.start(generateTeams(2, 2), true);
 
         //Set all matches to played
         setAllUpcommingMatchesPlayed(bracket);
@@ -267,12 +267,11 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(2);
-        bracket.start(generateTeams(12,2), seeding);
+        bracket.start(generateTeams(12,2), true);
 
 
         assertEquals(2,bracket.getGroups().size());
         for (RoundRobinGroup group: bracket.getGroups()) {
-            assertEquals(6, group.getTeamsWithoutDummy().size());
             assertEquals(6,group.getTeams().size());
             assertEquals(15,group.getMatches().size());
         }
@@ -292,12 +291,11 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(2);
-        bracket.start(generateTeams(10,2), seeding);
+        bracket.start(generateTeams(10,2), true);
 
         assertEquals(2,bracket.getGroups().size());
         for (RoundRobinGroup group: bracket.getGroups()) {
-            assertEquals(5, group.getTeamsWithoutDummy().size());
-            assertEquals(6, group.getTeams().size());
+            assertEquals(5, group.getTeams().size());
             assertEquals(10,group.getMatches().size());
         }
 
@@ -315,11 +313,10 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(3);
-        bracket.start(generateTeams(18,2), seeding);
+        bracket.start(generateTeams(18,2), true);
 
         assertEquals(3,bracket.getGroups().size());
         for (RoundRobinGroup group: bracket.getGroups()) {
-            assertEquals(6, group.getTeamsWithoutDummy().size());
             assertEquals(6,group.getTeams().size());
             assertEquals(15,group.getMatches().size());
         }
@@ -338,16 +335,14 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(3);
-        bracket.start(generateTeams(10,2), seeding);
+        bracket.start(generateTeams(10,2), true);
 
         assertEquals(3,bracket.getGroups().size());
         for (RoundRobinGroup group: bracket.getGroups()) {
 
-            if (group.getTeamsWithoutDummy().size() == 3) {
-                assertEquals(4,group.getTeams().size());
+            if (group.getTeams().size() == 3) {
                 assertEquals(3,group.getMatches().size());
-            } else if (group.getTeamsWithoutDummy().size() == 4) {
-                assertEquals(4,group.getTeams().size());
+            } else if (group.getTeams().size() == 4) {
                 assertEquals(6,group.getMatches().size());
             }
         }
@@ -371,7 +366,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(20);
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(5, bracket.getGroups().size());
     }
@@ -385,7 +380,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(0);
-        bracket.start(generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(1, bracket.getGroups().size());
     }
@@ -398,7 +393,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(numberOfGroups);
-        bracket.start(generateTeams(numberOfTeams, 2), seeding);
+        bracket.start(generateTeams(numberOfTeams, 2), true);
 
         ArrayList<RoundRobinGroup> groups = bracket.getGroups();
 
@@ -419,7 +414,7 @@ public class RoundRobinFormatTest {
 
         RoundRobinFormat bracket = new RoundRobinFormat();
         bracket.setNumberOfGroups(numberOfGroups);
-        bracket.start(generateTeams(numberOfTeams, 2), seeding);
+        bracket.start(generateTeams(numberOfTeams, 2), true);
 
         ArrayList<RoundRobinGroup> groups = bracket.getGroups();
 

--- a/test/dk/aau/cs/ds306e18/tournament/model/SingleEliminationFormatTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/SingleEliminationFormatTest.java
@@ -18,7 +18,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void amountOfMatchesTest01(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8,1), seeding);
+        bracket.start(TestUtilities.generateTeams(8,1), true);
         assertEquals(7, bracket.getAllMatches().size());
     }
 
@@ -26,7 +26,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void amountOfMatchesTest02() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(16,1), seeding);
+        bracket.start(TestUtilities.generateTeams(16,1), true);
         assertEquals(15, bracket.getAllMatches().size());
     }
 
@@ -34,7 +34,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void dependsOnFinalMatch01() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8,1), seeding);
+        bracket.start(TestUtilities.generateTeams(8,1), true);
         List<Match> matches = bracket.getAllMatches();
         for(int n = 1; n < matches.size(); n++) {
             assertTrue(matches.get(0).dependsOn(matches.get(n)));
@@ -45,7 +45,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void dependsOnFinalMatch02() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(16,1), seeding);
+        bracket.start(TestUtilities.generateTeams(16,1), true);
         List<Match> matches = bracket.getAllMatches();
         for(int n = 1; n < matches.size(); n++) {
             assertTrue(matches.get(0).dependsOn(matches.get(n)));
@@ -56,7 +56,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void dependsOnFinalMatch03() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateSeededTeams(10,1), seeding);
+        bracket.start(TestUtilities.generateSeededTeams(10,1), true);
         List<Match> matches = bracket.getAllMatches();
         for(int n = 1; n < matches.size(); n++) {
             assertTrue(matches.get(0).dependsOn(matches.get(n)));
@@ -68,7 +68,7 @@ public class SingleEliminationFormatTest {
     public void seedTest01(){
         ArrayList<Team> teamList = TestUtilities.generateSeededTeams(8,1);
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(teamList, seeding);
+        bracket.start(teamList, true);
         assertEquals(1, bracket.getAllMatches().get(bracket.getAllMatches().size()-1).getBlueTeam().getInitialSeedValue());
         assertEquals(8, bracket.getAllMatches().get(bracket.getAllMatches().size()-1).getOrangeTeam().getInitialSeedValue());
         assertEquals(4, bracket.getAllMatches().get(bracket.getAllMatches().size()-2).getBlueTeam().getInitialSeedValue());
@@ -83,7 +83,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void seedTest02(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateSeededTeams(7,1), seeding);
+        bracket.start(TestUtilities.generateSeededTeams(7,1), true);
         assertNull(bracket.getMatchesAsArray()[6]);
         assertEquals(1,bracket.getMatchesAsArray()[2].getBlueTeam().getInitialSeedValue());
     }
@@ -92,7 +92,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void seedTest03(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateSeededTeams(6,1), seeding);
+        bracket.start(TestUtilities.generateSeededTeams(6,1), true);
         assertNull(bracket.getMatchesAsArray()[4]);
         assertEquals(2,bracket.getMatchesAsArray()[1].getBlueTeam().getInitialSeedValue());
     }
@@ -102,7 +102,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void seedTest04(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateSeededTeams(5,1), seeding);
+        bracket.start(TestUtilities.generateSeededTeams(5,1), true);
         assertNull(bracket.getMatchesAsArray()[6]);
         assertNull(bracket.getMatchesAsArray()[4]);
         assertNull(bracket.getMatchesAsArray()[3]);
@@ -114,7 +114,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void upcomingMatchesTest01(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8,1), seeding);
+        bracket.start(TestUtilities.generateTeams(8,1), true);
         assertEquals(4, bracket.getUpcomingMatches().size());
         bracket.getUpcomingMatches().get(0).setHasBeenPlayed(true);
         assertEquals(3, bracket.getUpcomingMatches().size());
@@ -124,7 +124,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void upcomingMatchesTest02(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(6,1), seeding);
+        bracket.start(TestUtilities.generateTeams(6,1), true);
         assertEquals(2, bracket.getUpcomingMatches().size());
     }
 
@@ -132,7 +132,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void pendingMatchesTest01(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8,1), seeding);
+        bracket.start(TestUtilities.generateTeams(8,1), true);
         assertEquals(3, bracket.getPendingMatches().size());
         bracket.getAllMatches().get(bracket.getAllMatches().size()-1).setScores(1, 2, true);
         bracket.getAllMatches().get(bracket.getAllMatches().size()-2).setScores(1, 2, true);
@@ -143,7 +143,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void completedMatchesTest01(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8,1), seeding);
+        bracket.start(TestUtilities.generateTeams(8,1), true);
         assertEquals(0, bracket.getCompletedMatches().size());
         bracket.getAllMatches().get(bracket.getAllMatches().size()-1).setHasBeenPlayed(true);
         bracket.getAllMatches().get(bracket.getAllMatches().size()-2).setHasBeenPlayed(true);
@@ -191,7 +191,7 @@ public class SingleEliminationFormatTest {
     public void stageStatusTest01() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
         assertEquals(StageStatus.PENDING, bracket.getStatus());
-        bracket.start(TestUtilities.generateTeams(4, 1), seeding);
+        bracket.start(TestUtilities.generateTeams(4, 1), true);
         assertEquals(StageStatus.RUNNING, bracket.getStatus());
         bracket =  generateBracketsAndWins(4);
         assertEquals(StageStatus.CONCLUDED, bracket.getStatus());
@@ -201,7 +201,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void stageStatusTest02() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8, 1), seeding);
+        bracket.start(TestUtilities.generateTeams(8, 1), true);
         List<Match> arrayList = bracket.getAllMatches();
         arrayList.get(arrayList.size()-1).setBlueScore(1);
         arrayList.get(arrayList.size()-1).setHasBeenPlayed(true);
@@ -214,7 +214,7 @@ public class SingleEliminationFormatTest {
     @Test(expected = IllegalStateException.class)
     public void unPlayableMatch() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8, 1), seeding);
+        bracket.start(TestUtilities.generateTeams(8, 1), true);
         bracket.getAllMatches().get(0).setBlueScore(1);
     }
 
@@ -222,7 +222,7 @@ public class SingleEliminationFormatTest {
     @Test(expected = IllegalStateException.class)
     public void unPlayableMatch02() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8, 1), seeding);
+        bracket.start(TestUtilities.generateTeams(8, 1), true);
         bracket.getAllMatches().get(2).setHasBeenPlayed(true);
     }
 
@@ -230,7 +230,7 @@ public class SingleEliminationFormatTest {
      * @param amountOfTeams the amount of teams */
     private SingleEliminationFormat generateBracketsAndWins(int amountOfTeams) {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateSeededTeams(amountOfTeams,1), seeding);
+        bracket.start(TestUtilities.generateSeededTeams(amountOfTeams,1), true);
 
         for(int matchIndex = bracket.getAllMatches().size()-1 ; matchIndex >= 0; matchIndex--){
             if(bracket.getAllMatches().get(matchIndex).getBlueTeam().getInitialSeedValue() < bracket.getAllMatches().get(matchIndex).getOrangeTeam().getInitialSeedValue()) {

--- a/test/dk/aau/cs/ds306e18/tournament/model/SingleEliminationFormatTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/SingleEliminationFormatTest.java
@@ -18,7 +18,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void amountOfMatchesTest01(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8,1));
+        bracket.start(TestUtilities.generateTeams(8,1), seeding);
         assertEquals(7, bracket.getAllMatches().size());
     }
 
@@ -26,7 +26,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void amountOfMatchesTest02() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(16,1));
+        bracket.start(TestUtilities.generateTeams(16,1), seeding);
         assertEquals(15, bracket.getAllMatches().size());
     }
 
@@ -34,7 +34,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void dependsOnFinalMatch01() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8,1));
+        bracket.start(TestUtilities.generateTeams(8,1), seeding);
         List<Match> matches = bracket.getAllMatches();
         for(int n = 1; n < matches.size(); n++) {
             assertTrue(matches.get(0).dependsOn(matches.get(n)));
@@ -45,7 +45,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void dependsOnFinalMatch02() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(16,1));
+        bracket.start(TestUtilities.generateTeams(16,1), seeding);
         List<Match> matches = bracket.getAllMatches();
         for(int n = 1; n < matches.size(); n++) {
             assertTrue(matches.get(0).dependsOn(matches.get(n)));
@@ -56,7 +56,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void dependsOnFinalMatch03() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateSeededTeams(10,1));
+        bracket.start(TestUtilities.generateSeededTeams(10,1), seeding);
         List<Match> matches = bracket.getAllMatches();
         for(int n = 1; n < matches.size(); n++) {
             assertTrue(matches.get(0).dependsOn(matches.get(n)));
@@ -68,7 +68,7 @@ public class SingleEliminationFormatTest {
     public void seedTest01(){
         ArrayList<Team> teamList = TestUtilities.generateSeededTeams(8,1);
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(teamList);
+        bracket.start(teamList, seeding);
         assertEquals(1, bracket.getAllMatches().get(bracket.getAllMatches().size()-1).getBlueTeam().getInitialSeedValue());
         assertEquals(8, bracket.getAllMatches().get(bracket.getAllMatches().size()-1).getOrangeTeam().getInitialSeedValue());
         assertEquals(4, bracket.getAllMatches().get(bracket.getAllMatches().size()-2).getBlueTeam().getInitialSeedValue());
@@ -83,7 +83,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void seedTest02(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateSeededTeams(7,1));
+        bracket.start(TestUtilities.generateSeededTeams(7,1), seeding);
         assertNull(bracket.getMatchesAsArray()[6]);
         assertEquals(1,bracket.getMatchesAsArray()[2].getBlueTeam().getInitialSeedValue());
     }
@@ -92,7 +92,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void seedTest03(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateSeededTeams(6,1));
+        bracket.start(TestUtilities.generateSeededTeams(6,1), seeding);
         assertNull(bracket.getMatchesAsArray()[4]);
         assertEquals(2,bracket.getMatchesAsArray()[1].getBlueTeam().getInitialSeedValue());
     }
@@ -102,7 +102,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void seedTest04(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateSeededTeams(5,1));
+        bracket.start(TestUtilities.generateSeededTeams(5,1), seeding);
         assertNull(bracket.getMatchesAsArray()[6]);
         assertNull(bracket.getMatchesAsArray()[4]);
         assertNull(bracket.getMatchesAsArray()[3]);
@@ -114,7 +114,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void upcomingMatchesTest01(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8,1));
+        bracket.start(TestUtilities.generateTeams(8,1), seeding);
         assertEquals(4, bracket.getUpcomingMatches().size());
         bracket.getUpcomingMatches().get(0).setHasBeenPlayed(true);
         assertEquals(3, bracket.getUpcomingMatches().size());
@@ -124,7 +124,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void upcomingMatchesTest02(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(6,1));
+        bracket.start(TestUtilities.generateTeams(6,1), seeding);
         assertEquals(2, bracket.getUpcomingMatches().size());
     }
 
@@ -132,7 +132,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void pendingMatchesTest01(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8,1));
+        bracket.start(TestUtilities.generateTeams(8,1), seeding);
         assertEquals(3, bracket.getPendingMatches().size());
         bracket.getAllMatches().get(bracket.getAllMatches().size()-1).setScores(1, 2, true);
         bracket.getAllMatches().get(bracket.getAllMatches().size()-2).setScores(1, 2, true);
@@ -143,7 +143,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void completedMatchesTest01(){
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8,1));
+        bracket.start(TestUtilities.generateTeams(8,1), seeding);
         assertEquals(0, bracket.getCompletedMatches().size());
         bracket.getAllMatches().get(bracket.getAllMatches().size()-1).setHasBeenPlayed(true);
         bracket.getAllMatches().get(bracket.getAllMatches().size()-2).setHasBeenPlayed(true);
@@ -191,7 +191,7 @@ public class SingleEliminationFormatTest {
     public void stageStatusTest01() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
         assertEquals(StageStatus.PENDING, bracket.getStatus());
-        bracket.start(TestUtilities.generateTeams(4, 1));
+        bracket.start(TestUtilities.generateTeams(4, 1), seeding);
         assertEquals(StageStatus.RUNNING, bracket.getStatus());
         bracket =  generateBracketsAndWins(4);
         assertEquals(StageStatus.CONCLUDED, bracket.getStatus());
@@ -201,7 +201,7 @@ public class SingleEliminationFormatTest {
     @Test
     public void stageStatusTest02() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8, 1));
+        bracket.start(TestUtilities.generateTeams(8, 1), seeding);
         List<Match> arrayList = bracket.getAllMatches();
         arrayList.get(arrayList.size()-1).setBlueScore(1);
         arrayList.get(arrayList.size()-1).setHasBeenPlayed(true);
@@ -214,7 +214,7 @@ public class SingleEliminationFormatTest {
     @Test(expected = IllegalStateException.class)
     public void unPlayableMatch() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8, 1));
+        bracket.start(TestUtilities.generateTeams(8, 1), seeding);
         bracket.getAllMatches().get(0).setBlueScore(1);
     }
 
@@ -222,7 +222,7 @@ public class SingleEliminationFormatTest {
     @Test(expected = IllegalStateException.class)
     public void unPlayableMatch02() {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateTeams(8, 1));
+        bracket.start(TestUtilities.generateTeams(8, 1), seeding);
         bracket.getAllMatches().get(2).setHasBeenPlayed(true);
     }
 
@@ -230,7 +230,7 @@ public class SingleEliminationFormatTest {
      * @param amountOfTeams the amount of teams */
     private SingleEliminationFormat generateBracketsAndWins(int amountOfTeams) {
         SingleEliminationFormat bracket = new SingleEliminationFormat();
-        bracket.start(TestUtilities.generateSeededTeams(amountOfTeams,1));
+        bracket.start(TestUtilities.generateSeededTeams(amountOfTeams,1), seeding);
 
         for(int matchIndex = bracket.getAllMatches().size()-1 ; matchIndex >= 0; matchIndex--){
             if(bracket.getAllMatches().get(matchIndex).getBlueTeam().getInitialSeedValue() < bracket.getAllMatches().get(matchIndex).getOrangeTeam().getInitialSeedValue()) {

--- a/test/dk/aau/cs/ds306e18/tournament/model/SingleEliminationFormatTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/SingleEliminationFormatTest.java
@@ -226,6 +226,93 @@ public class SingleEliminationFormatTest {
         bracket.getAllMatches().get(2).setHasBeenPlayed(true);
     }
 
+    @Test
+    public void withSeeding01() {
+
+        int numberOfTeams = 4;
+        ArrayList<Team> teams = TestUtilities.generateTeams(numberOfTeams, 1);
+
+        SingleEliminationFormat singleelimination = new SingleEliminationFormat();
+        singleelimination.start(teams, true);
+
+        Match matchOne = singleelimination.getAllMatches().get(2);
+        assertSame(teams.get(0), matchOne.getBlueTeam());
+        assertSame(teams.get(3), matchOne.getOrangeTeam());
+
+        Match matchTwo = singleelimination.getAllMatches().get(1);
+        assertSame(teams.get(1), matchTwo.getBlueTeam());
+        assertSame(teams.get(2), matchTwo.getOrangeTeam());
+    }
+
+    @Test
+    public void withSeeding02() {
+
+        int numberOfTeams = 8;
+        ArrayList<Team> teams = TestUtilities.generateTeams(numberOfTeams, 1);
+
+        SingleEliminationFormat singleelimination = new SingleEliminationFormat();
+        singleelimination.start(teams, true);
+
+        Match matchOne = singleelimination.getAllMatches().get(6);
+        assertSame(teams.get(0), matchOne.getBlueTeam());
+        assertSame(teams.get(7), matchOne.getOrangeTeam());
+
+        Match matchTwo = singleelimination.getAllMatches().get(5);
+        assertSame(teams.get(3), matchTwo.getBlueTeam());
+        assertSame(teams.get(4), matchTwo.getOrangeTeam());
+
+        Match matchThree = singleelimination.getAllMatches().get(4);
+        assertSame(teams.get(1), matchThree.getBlueTeam());
+        assertSame(teams.get(6), matchThree.getOrangeTeam());
+
+        Match matchFour = singleelimination.getAllMatches().get(3);
+        assertSame(teams.get(2), matchFour.getBlueTeam());
+        assertSame(teams.get(5), matchFour.getOrangeTeam());
+    }
+
+    @Test
+    public void withoutSeeding01() {
+        int numberOfTeams = 4;
+        ArrayList<Team> teams = TestUtilities.generateTeams(numberOfTeams, 1);
+
+        SingleEliminationFormat singleelimination = new SingleEliminationFormat();
+        singleelimination.start(teams, false);
+
+        Match matchOne = singleelimination.getAllMatches().get(2);
+        assertSame(teams.get(0), matchOne.getBlueTeam());
+        assertSame(teams.get(1), matchOne.getOrangeTeam());
+
+        Match matchTwo = singleelimination.getAllMatches().get(1);
+        assertSame(teams.get(2), matchTwo.getBlueTeam());
+        assertSame(teams.get(3), matchTwo.getOrangeTeam());
+    }
+
+    @Test
+    public void withoutSeeding02() {
+
+        int numberOfTeams = 8;
+        ArrayList<Team> teams = TestUtilities.generateTeams(numberOfTeams, 1);
+
+        SingleEliminationFormat singleelimination = new SingleEliminationFormat();
+        singleelimination.start(teams, false);
+
+        Match matchOne = singleelimination.getAllMatches().get(6);
+        assertSame(teams.get(0), matchOne.getBlueTeam());
+        assertSame(teams.get(1), matchOne.getOrangeTeam());
+
+        Match matchTwo = singleelimination.getAllMatches().get(5);
+        assertSame(teams.get(2), matchTwo.getBlueTeam());
+        assertSame(teams.get(3), matchTwo.getOrangeTeam());
+
+        Match matchThree = singleelimination.getAllMatches().get(4);
+        assertSame(teams.get(4), matchThree.getBlueTeam());
+        assertSame(teams.get(5), matchThree.getOrangeTeam());
+
+        Match matchFour = singleelimination.getAllMatches().get(3);
+        assertSame(teams.get(6), matchFour.getBlueTeam());
+        assertSame(teams.get(7), matchFour.getOrangeTeam());
+    }
+
     /** Generates a bracket and sets wins according to the best seed
      * @param amountOfTeams the amount of teams */
     private SingleEliminationFormat generateBracketsAndWins(int amountOfTeams) {

--- a/test/dk/aau/cs/ds306e18/tournament/model/SwissFormatTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/SwissFormatTest.java
@@ -22,7 +22,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(numberOfTeams - 1, bracket.getMaxRoundsPossible());
     }
@@ -35,7 +35,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(numberOfTeams, bracket.getMaxRoundsPossible());
     }
@@ -48,7 +48,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(numberOfTeams, bracket.getMaxRoundsPossible());
     }
@@ -61,7 +61,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         List<Match> allMatches = bracket.getAllMatches();
 
@@ -76,7 +76,7 @@ public class SwissFormatTest {
         int teamSize = 0;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         List<Match> allMatches = bracket.getAllMatches();
 
@@ -91,7 +91,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         //The first round.
         assertEquals(numberOfTeams/2, bracket.getAllMatches().size());
@@ -114,7 +114,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         List<Match> unplayedMatches = bracket.getPendingMatches();
 
@@ -129,7 +129,7 @@ public class SwissFormatTest {
         int teamSize = 0;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         List<Match> unplayedMatches = bracket.getPendingMatches();
 
@@ -143,7 +143,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         //All has to be played
         setAllMatchesPlayed(bracket);
@@ -158,7 +158,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(numberOfTeams/2 , bracket.getUpcomingMatches().size());
     }
@@ -170,7 +170,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(numberOfTeams/2 , bracket.getUpcomingMatches().size());
     }
@@ -182,7 +182,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(0 , bracket.getUpcomingMatches().size());
     }
@@ -193,7 +193,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         assertEquals(0 , bracket.getCompletedMatches().size());
     }
@@ -204,7 +204,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         setAllMatchesPlayed(bracket);
 
@@ -219,7 +219,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         //All has to be played
         setAllMatchesPlayed(bracket);
@@ -235,7 +235,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         //All has to be played
         setAllMatchesPlayed(bracket);
@@ -251,7 +251,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         assertFalse(bracket.startNextRound());
     }
@@ -267,7 +267,7 @@ public class SwissFormatTest {
 
         //Create the bracket with the teams
         SwissFormat bracket = new SwissFormat();
-        bracket.start(teams, seeding);
+        bracket.start(teams, true);
 
         //Generate all rounds and fill result
         do{
@@ -307,7 +307,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         //All has to be played
         setAllMatchesPlayed(bracket);
@@ -322,7 +322,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         assertFalse(bracket.hasUnstartedRounds());
     }
@@ -334,7 +334,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         assertTrue(bracket.hasUnstartedRounds());
     }
@@ -347,7 +347,7 @@ public class SwissFormatTest {
 
         SwissFormat bracket = new SwissFormat();
         bracket.setRoundCount(1);
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         assertFalse(bracket.hasUnstartedRounds());
     }
@@ -359,7 +359,7 @@ public class SwissFormatTest {
 
         SwissFormat bracket = new SwissFormat();
         bracket.setRoundCount(3);
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         assertTrue(bracket.hasUnstartedRounds());
         assertEquals(3, bracket.getRoundCount());
@@ -372,7 +372,7 @@ public class SwissFormatTest {
 
         SwissFormat bracket = new SwissFormat();
         bracket.setRoundCount(44444);
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
 
         assertTrue(bracket.hasUnstartedRounds());
         assertEquals(7, bracket.getRoundCount());
@@ -391,7 +391,7 @@ public class SwissFormatTest {
 
         SwissFormat bracket = new SwissFormat();
         bracket.setRoundCount(3);
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), true);
         bracket.setRoundCount(2);
     }
 
@@ -407,7 +407,7 @@ public class SwissFormatTest {
     public void getStatus02(){ //Running
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(4, 2), seeding);
+        bracket.start(TestUtilities.generateTeams(4, 2), true);
         bracket.startNextRound();
 
         assertEquals(StageStatus.RUNNING, bracket.getStatus());
@@ -417,7 +417,7 @@ public class SwissFormatTest {
     public void getStatus03(){ //Concluded // max number of rounds and all played
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(2,2), seeding);
+        bracket.start(TestUtilities.generateTeams(2,2), true);
         bracket.startNextRound();
 
         //Set all matches to played
@@ -430,7 +430,7 @@ public class SwissFormatTest {
     public void getStatus04(){ //Concluded //max number of round but not played
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(2,2), seeding);
+        bracket.start(TestUtilities.generateTeams(2,2), true);
         bracket.startNextRound();
 
         assertNotEquals(StageStatus.CONCLUDED, bracket.getStatus());
@@ -440,7 +440,7 @@ public class SwissFormatTest {
     public void getTopTeams01(){ //No teams
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(new ArrayList<Team>(), seeding);
+        bracket.start(new ArrayList<Team>(), true);
 
         assertEquals(0, bracket.getTopTeams(10, new TieBreakerBySeed()).size());
     }
@@ -450,7 +450,7 @@ public class SwissFormatTest {
 
         SwissFormat bracket = new SwissFormat();
         ArrayList<Team> inputTeams = TestUtilities.generateTeams(4,2);
-        bracket.start(inputTeams, seeding);
+        bracket.start(inputTeams, true);
 
         setAllMatchesPlayed(bracket);
         //All teams now have the same amount of points.

--- a/test/dk/aau/cs/ds306e18/tournament/model/SwissFormatTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/SwissFormatTest.java
@@ -22,7 +22,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(numberOfTeams - 1, bracket.getMaxRoundsPossible());
     }
@@ -35,7 +35,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(numberOfTeams, bracket.getMaxRoundsPossible());
     }
@@ -48,7 +48,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(numberOfTeams, bracket.getMaxRoundsPossible());
     }
@@ -61,7 +61,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         List<Match> allMatches = bracket.getAllMatches();
 
@@ -76,7 +76,7 @@ public class SwissFormatTest {
         int teamSize = 0;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         List<Match> allMatches = bracket.getAllMatches();
 
@@ -91,7 +91,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         //The first round.
         assertEquals(numberOfTeams/2, bracket.getAllMatches().size());
@@ -114,7 +114,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         List<Match> unplayedMatches = bracket.getPendingMatches();
 
@@ -129,7 +129,7 @@ public class SwissFormatTest {
         int teamSize = 0;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         List<Match> unplayedMatches = bracket.getPendingMatches();
 
@@ -143,7 +143,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         //All has to be played
         setAllMatchesPlayed(bracket);
@@ -158,7 +158,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(numberOfTeams/2 , bracket.getUpcomingMatches().size());
     }
@@ -170,7 +170,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(numberOfTeams/2 , bracket.getUpcomingMatches().size());
     }
@@ -182,7 +182,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(0 , bracket.getUpcomingMatches().size());
     }
@@ -193,7 +193,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         assertEquals(0 , bracket.getCompletedMatches().size());
     }
@@ -204,7 +204,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         setAllMatchesPlayed(bracket);
 
@@ -219,7 +219,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         //All has to be played
         setAllMatchesPlayed(bracket);
@@ -235,7 +235,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         //All has to be played
         setAllMatchesPlayed(bracket);
@@ -251,7 +251,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         assertFalse(bracket.startNextRound());
     }
@@ -267,7 +267,7 @@ public class SwissFormatTest {
 
         //Create the bracket with the teams
         SwissFormat bracket = new SwissFormat();
-        bracket.start(teams);
+        bracket.start(teams, seeding);
 
         //Generate all rounds and fill result
         do{
@@ -307,7 +307,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         //All has to be played
         setAllMatchesPlayed(bracket);
@@ -322,7 +322,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         assertFalse(bracket.hasUnstartedRounds());
     }
@@ -334,7 +334,7 @@ public class SwissFormatTest {
         int teamSize = 2;
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         assertTrue(bracket.hasUnstartedRounds());
     }
@@ -347,7 +347,7 @@ public class SwissFormatTest {
 
         SwissFormat bracket = new SwissFormat();
         bracket.setRoundCount(1);
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         assertFalse(bracket.hasUnstartedRounds());
     }
@@ -359,7 +359,7 @@ public class SwissFormatTest {
 
         SwissFormat bracket = new SwissFormat();
         bracket.setRoundCount(3);
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         assertTrue(bracket.hasUnstartedRounds());
         assertEquals(3, bracket.getRoundCount());
@@ -372,7 +372,7 @@ public class SwissFormatTest {
 
         SwissFormat bracket = new SwissFormat();
         bracket.setRoundCount(44444);
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
 
         assertTrue(bracket.hasUnstartedRounds());
         assertEquals(7, bracket.getRoundCount());
@@ -391,7 +391,7 @@ public class SwissFormatTest {
 
         SwissFormat bracket = new SwissFormat();
         bracket.setRoundCount(3);
-        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize));
+        bracket.start(TestUtilities.generateTeams(numberOfTeams, teamSize), seeding);
         bracket.setRoundCount(2);
     }
 
@@ -407,7 +407,7 @@ public class SwissFormatTest {
     public void getStatus02(){ //Running
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(4, 2));
+        bracket.start(TestUtilities.generateTeams(4, 2), seeding);
         bracket.startNextRound();
 
         assertEquals(StageStatus.RUNNING, bracket.getStatus());
@@ -417,7 +417,7 @@ public class SwissFormatTest {
     public void getStatus03(){ //Concluded // max number of rounds and all played
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(2,2));
+        bracket.start(TestUtilities.generateTeams(2,2), seeding);
         bracket.startNextRound();
 
         //Set all matches to played
@@ -430,7 +430,7 @@ public class SwissFormatTest {
     public void getStatus04(){ //Concluded //max number of round but not played
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(TestUtilities.generateTeams(2,2));
+        bracket.start(TestUtilities.generateTeams(2,2), seeding);
         bracket.startNextRound();
 
         assertNotEquals(StageStatus.CONCLUDED, bracket.getStatus());
@@ -440,7 +440,7 @@ public class SwissFormatTest {
     public void getTopTeams01(){ //No teams
 
         SwissFormat bracket = new SwissFormat();
-        bracket.start(new ArrayList<Team>());
+        bracket.start(new ArrayList<Team>(), seeding);
 
         assertEquals(0, bracket.getTopTeams(10, new TieBreakerBySeed()).size());
     }
@@ -450,7 +450,7 @@ public class SwissFormatTest {
 
         SwissFormat bracket = new SwissFormat();
         ArrayList<Team> inputTeams = TestUtilities.generateTeams(4,2);
-        bracket.start(inputTeams);
+        bracket.start(inputTeams, seeding);
 
         setAllMatchesPlayed(bracket);
         //All teams now have the same amount of points.

--- a/test/dk/aau/cs/ds306e18/tournament/model/tiebreaker/TieBreakerByGoalDiffTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/tiebreaker/TieBreakerByGoalDiffTest.java
@@ -22,7 +22,7 @@ public class TieBreakerByGoalDiffTest {
             teamList.add(new Team("Team" + Integer.toString(i), botList, i+1, "team" + Integer.toString(i)));
             botList.clear();
         }
-        bracket.start(teamList, seeding);
+        bracket.start(teamList, true);
         bracket.getAllMatches().get(6).setScores(2, 0, true);
         bracket.getAllMatches().get(5).setScores(5, 0, true);
         bracket.getAllMatches().get(4).setScores(3, 2, true);

--- a/test/dk/aau/cs/ds306e18/tournament/model/tiebreaker/TieBreakerByGoalDiffTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/tiebreaker/TieBreakerByGoalDiffTest.java
@@ -22,7 +22,7 @@ public class TieBreakerByGoalDiffTest {
             teamList.add(new Team("Team" + Integer.toString(i), botList, i+1, "team" + Integer.toString(i)));
             botList.clear();
         }
-        bracket.start(teamList);
+        bracket.start(teamList, seeding);
         bracket.getAllMatches().get(6).setScores(2, 0, true);
         bracket.getAllMatches().get(5).setScores(5, 0, true);
         bracket.getAllMatches().get(4).setScores(3, 2, true);


### PR DESCRIPTION
Three seeding options:
- **Seed by order in participant list**: Normal seeding
- **No seeding**: The teams are placed directly into the bracket/groups
- **Random seeding**: Shuffles the teams

The swiss algorithm is currently unaffected as it doesn't consinder seeding. This should be added when the algorithm is updated to solve issue #5

Resolves #10 