### PR TITLE
Reduced testRoundRobinBracket03 number of teams from 1234 to 256.

### DIFF
--- a/test/dk/aau/cs/ds306e18/tournament/model/RoundRobinFormatTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/RoundRobinFormatTest.java
@@ -43,7 +43,7 @@ public class RoundRobinFormatTest {
     @Test
     public void testRoundRobinBracket03() {
 
-        int numberOfTeams = 1234;
+        int numberOfTeams = 256;
         int teamSize = 1;
 
         RoundRobinFormat bracket = new RoundRobinFormat();


### PR DESCRIPTION
Runtime of `testRoundRobinBracket03` has been reduced from 3.7s to 280ms on my `4600U`. This resolves #43.