### PR TITLE
Matches with unknown players no longer throws an exception when double-clicked.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
 #### Unreleased (dev branch)
-- Matches are now displayed slightly bigger
-- Matches now has an identifier and pending matches will display which matches they depend on. E.g. "Winner of X" vs "Loser of Y"
+- Matches are now displayed slightly bigger. - NicEastvillage
+- Matches now has an identifier and pending matches will display which matches they depend on. E.g. "Winner of X" vs "Loser of Y". - NicEastvillage
+- Fixed a bug that occurred when matches with to-be-determined players were double-clicked. #51 - NicEastvillage
 
 
 #### Version 1.1.2 - 23. Jan 2019

--- a/src/dk/aau/cs/ds306e18/tournament/ui/MatchVisualController.java
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/MatchVisualController.java
@@ -33,14 +33,15 @@ public class MatchVisualController implements MatchChangeListener {
     /** Gets called when a match is clicked. */
     @FXML
     void matchClicked(MouseEvent event) {
-        if (event.getButton().equals(MouseButton.PRIMARY)){
-            if (event.getClickCount() == 2){
-                boc.openEditMatchPopup();
-            }
-        }
-
         matchRoot.getStyleClass().add("selectedMatch");
         boc.setSelectedMatch(this);
+
+        if (showedMatch.isReadyToPlay()
+                && event.getButton().equals(MouseButton.PRIMARY)
+                && event.getClickCount() == 2) {
+
+            boc.openEditMatchPopup();
+        }
     }
 
     /** Used to set the BracketOverviewController. Is used to ref that this is clicked/Selected. */


### PR DESCRIPTION
Resolves #51 