### PR TITLE
Added ability to play with Psyonix Allstar bots

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+#### Unreleased changes (dev branch)
+- Added support for Psyonix Allstar bot. #13 - NicEastvillage
+
 #### Version 1.2.1 - 4. March 2019
 - Added ability to swap team colors in a match. #49 - NicEastvillage
 - Fixed a bug where changing the score of a match without affecting the outcome would reset subsequent matches. #53 - NicEastvillage

--- a/src/dk/aau/cs/ds306e18/tournament/model/Bot.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/Bot.java
@@ -8,6 +8,15 @@ public class Bot implements Cloneable {
     private String developer;
     private String description;
     private String configPath;
+    private boolean isPsyonixBot;
+
+    public Bot(String name, String developer, String configPath, String description, boolean isPsyonixBot) {
+        this.name = name;
+        this.developer = developer;
+        this.configPath = configPath;
+        this.description = description;
+        this.isPsyonixBot = isPsyonixBot;
+    }
 
     public Bot(String name, String developer, String configPath, String description) {
         this.name = name;
@@ -59,13 +68,21 @@ public class Bot implements Cloneable {
         this.configPath = configPath;
     }
 
+    public boolean isPsyonixBot() {
+        return isPsyonixBot;
+    }
+
+    public void setPsyonixBot(boolean psyonixBot) {
+        isPsyonixBot = psyonixBot;
+    }
+
     public String toString() {
         return name;
     }
 
     @Override
     public Bot clone() {
-        return new Bot(name, developer, configPath, description);
+        return new Bot(name, developer, configPath, description, isPsyonixBot);
     }
 
     @Override

--- a/src/dk/aau/cs/ds306e18/tournament/model/Bot.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/Bot.java
@@ -92,12 +92,14 @@ public class Bot implements Cloneable {
         Bot bot = (Bot) o;
         return Objects.equals(getName(), bot.getName()) &&
                 Objects.equals(getDeveloper(), bot.getDeveloper()) &&
-                Objects.equals(getConfigPath(), bot.getConfigPath());
+                Objects.equals(getConfigPath(), bot.getConfigPath()) &&
+                Objects.equals(getDescription(), bot.getDescription()) &&
+                Objects.equals(isPsyonixBot(), bot.isPsyonixBot());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getName(), getDeveloper(), getConfigPath());
+        return Objects.hash(getName(), getDeveloper(), getConfigPath(), getDescription(), isPsyonixBot());
     }
 
 }

--- a/src/dk/aau/cs/ds306e18/tournament/model/BotSkill.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/BotSkill.java
@@ -1,0 +1,17 @@
+package dk.aau.cs.ds306e18.tournament.model;
+
+public enum BotSkill {
+    ROOKIE("0.0"),
+    PRO("0.5"),
+    ALLSTAR("1.0");
+
+    private final String configValue;
+
+    BotSkill(String configValue) {
+        this.configValue = configValue;
+    }
+
+    public String getConfigValue() {
+        return configValue;
+    }
+}

--- a/src/dk/aau/cs/ds306e18/tournament/model/BotType.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/BotType.java
@@ -1,8 +1,13 @@
-package dk.aau.cs.ds306e18.tournament.utility.configuration;
+package dk.aau.cs.ds306e18.tournament.model;
 
 /** Enum over supported bot-types in the rlbot.cfg */
 public enum BotType {
-    HUMAN("human"), RLBOT("rlbot"), PSYONIX("psyonix"), PARTY_MEMBER_BOT("party_member_bot"), CONTROLLER_PASSTHROUGH("controller_passthrough"), SPECTATOR("");
+    HUMAN("human"),
+    RLBOT("rlbot"),
+    PSYONIX("psyonix"),
+    PARTY_MEMBER_BOT("party_member_bot"),
+    CONTROLLER_PASSTHROUGH("controller_passthrough"),
+    SPECTATOR("");
 
     private String configValue;
 

--- a/src/dk/aau/cs/ds306e18/tournament/ui/ParticipantSettingsTabController.java
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/ParticipantSettingsTabController.java
@@ -34,6 +34,7 @@ public class ParticipantSettingsTabController {
     @FXML private TextField teamNameTextField;
     @FXML private Spinner<Integer> seedSpinner;
     @FXML private TextField botNameTextField;
+    @FXML private RadioButton isPsyonixCheckbox;
     @FXML private TextField developerTextField;
     @FXML private TextArea botDescription;
     @FXML private Button configPathBtn;
@@ -339,12 +340,13 @@ public class ParticipantSettingsTabController {
             botSettingsVbox.setVisible(true);
             Bot selectedBot = Tournament.get().getTeams().get(getSelectedTeamIndex()).getBots().get(botsListView.getSelectionModel().getSelectedIndex());
             botNameTextField.setText(selectedBot.getName());
+            isPsyonixCheckbox.setSelected(selectedBot.isPsyonixBot());
             developerTextField.setText(selectedBot.getDeveloper());
             botDescription.setText(selectedBot.getDescription());
             updateConfigPathTextField();
 
         } else {
-            //if no bot is selected clear the fields and hide the botsettgins box.
+            // If no bot is selected clear the fields and hide the bot settings box.
             clearBotFields();
         }
         //Check for empty names
@@ -553,5 +555,10 @@ public class ParticipantSettingsTabController {
 
         addBotBtn.setDisable(selectedTeam != null && selectedTeam.getBots().size() >= Team.MAX_SIZE);
         removeBotBtn.setDisable(selectedBot == null);
+    }
+
+    public void onActionPsyonixToggled(ActionEvent actionEvent) {
+        Bot selectedBot = botsListView.getSelectionModel().getSelectedItem();
+        selectedBot.setPsyonixBot(isPsyonixCheckbox.isSelected());
     }
 }

--- a/src/dk/aau/cs/ds306e18/tournament/ui/layout/ParticipantSettingsTab.fxml
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/layout/ParticipantSettingsTab.fxml
@@ -5,9 +5,11 @@
 <?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
+<?import javafx.scene.control.RadioButton?>
 <?import javafx.scene.control.Spinner?>
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.control.TextField?>
+<?import javafx.scene.effect.Blend?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
@@ -178,7 +180,7 @@
             <Insets bottom="16.0" />
          </padding>
       </VBox>
-      <VBox id="PS-rightside" fx:id="botSettingsVbox" maxWidth="360.0" minWidth="360.0" prefWidth="360.0" spacing="10.0" visible="false">
+      <VBox id="PS-rightside" fx:id="botSettingsVbox" maxWidth="360.0" minWidth="360.0" prefWidth="360.0" spacing="10.0">
          <children>
             <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Bot Settings" wrappingWidth="208.8034381866455">
                <font>
@@ -201,6 +203,11 @@
                   <Insets />
                </VBox.margin>
             </TextField>
+            <RadioButton fx:id="isPsyonixCheckbox" mnemonicParsing="false" onAction="#onActionPsyonixToggled" text=" Psyonix Allstar (you must set a config path anyway)">
+               <effect>
+                  <Blend />
+               </effect>
+            </RadioButton>
             <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Developer:">
                <font>
                   <Font size="16.0" />

--- a/src/dk/aau/cs/ds306e18/tournament/utility/configuration/RLBotConfig.java
+++ b/src/dk/aau/cs/ds306e18/tournament/utility/configuration/RLBotConfig.java
@@ -1,6 +1,8 @@
 package dk.aau.cs.ds306e18.tournament.utility.configuration;
 
 import dk.aau.cs.ds306e18.tournament.model.Bot;
+import dk.aau.cs.ds306e18.tournament.model.BotSkill;
+import dk.aau.cs.ds306e18.tournament.model.BotType;
 import dk.aau.cs.ds306e18.tournament.model.match.Match;
 
 public class RLBotConfig extends ConfigFileEditor {
@@ -15,6 +17,7 @@ public class RLBotConfig extends ConfigFileEditor {
     private final static String PARAMETER_PARTICIPANT_CONFIG = "participant_config_";
     private final static String PARAMETER_PARTICIPANT_TEAM = "participant_team_";
     private final static String PARAMETER_PARTICIPANT_TYPE = "participant_type_";
+    private final static String PARAMETER_PARTICIPANT_SKILL = "participant_bot_skill_";
 
 
     private final static int PARAMETER_BLUE_TEAM = 0;
@@ -65,6 +68,13 @@ public class RLBotConfig extends ConfigFileEditor {
     }
 
     /**
+     * Sets participant skill of given participantIndex in RLBotConfig
+     */
+    private void setParticipantSkill(BotSkill skill, int participantIndex) {
+        editLine(SECTION_PARTICIPANT_CONFIGURATION, PARAMETER_PARTICIPANT_SKILL + participantIndex, skill.getConfigValue());
+    }
+
+    /**
      * Sets the number of participants for the RLBotConfig, converting int to String
      */
     private void setNumberOfParticipants(int participantIndex) {
@@ -86,20 +96,13 @@ public class RLBotConfig extends ConfigFileEditor {
 
         // for blue team, edit numbered parameters by incremented count of participants
         for (Bot bot : match.getBlueTeam().getBots()) {
-            // edit participant_config parameter to current bots config path
-            setParticipantConfigPath(bot.getConfigPath(), numParticipants);
-            // edit participant_team parameter to blue-team constant
-            setParticipantTeam(PARAMETER_BLUE_TEAM, numParticipants);
-            // edit participant_type parameter to RLBot-participant constant
-            setParticipantType(BotType.RLBOT, numParticipants);
+            setupParticipant(bot, numParticipants, PARAMETER_BLUE_TEAM);
             numParticipants++;
         }
 
         // for orange team, edit numbered parameters by incremented count of participants
         for (Bot bot : match.getOrangeTeam().getBots()) {
-            setParticipantConfigPath(bot.getConfigPath(), numParticipants);
-            setParticipantTeam(PARAMETER_ORANGE_TEAM, numParticipants);
-            setParticipantType(BotType.RLBOT, numParticipants);
+            setupParticipant(bot, numParticipants, PARAMETER_ORANGE_TEAM);
             numParticipants++;
         }
 
@@ -109,5 +112,13 @@ public class RLBotConfig extends ConfigFileEditor {
         // when configured, validate syntax and return boolean set by validateConfigSyntax
         validateConfigSyntax();
         return isValid();
+    }
+
+    /** Setup the parameters for a bot in the config file */
+    public void setupParticipant(Bot bot, int index, int team) {
+        setParticipantConfigPath(bot.getConfigPath(), index);
+        setParticipantTeam(team, index);
+        setParticipantType(bot.isPsyonixBot() ? BotType.PSYONIX : BotType.RLBOT, index);
+        setParticipantSkill(BotSkill.ALLSTAR, index);
     }
 }

--- a/test/dk/aau/cs/ds306e18/tournament/model/BotTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/BotTest.java
@@ -1,0 +1,14 @@
+package dk.aau.cs.ds306e18.tournament.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BotTest {
+
+    @Test
+    public void clone01() {
+        Bot bot = new Bot("name", "dev", "path", "desc", true);
+        assertEquals(bot, bot.clone());
+    }
+}


### PR DESCRIPTION
When a bot is selected, there's now a checkbox labeled "Psyonix Allstar (you must set a config file anyway)" in the bot settings panel. When checked, the bot will be a Psyonix Allstar bot ingame. However, as the label suggest, the bot must have a path to a config file where it's name and appearance config is defined.

Resolves #13 