### PR TITLE
Fixed issue involving internal paths

### DIFF
--- a/src/dk/aau/cs/ds306e18/tournament/settings/SettingsDirectory.java
+++ b/src/dk/aau/cs/ds306e18/tournament/settings/SettingsDirectory.java
@@ -1,5 +1,6 @@
 package dk.aau.cs.ds306e18.tournament.settings;
 
+import dk.aau.cs.ds306e18.tournament.Main;
 import dk.aau.cs.ds306e18.tournament.utility.FileOperations;
 
 import java.io.IOException;
@@ -7,8 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-
-import static dk.aau.cs.ds306e18.tournament.utility.FileOperations.internalPath;
 
 /**
  * This class contains paths to all the files in the settings directory, which makes it easy to refer to the any given
@@ -35,7 +34,7 @@ public class SettingsDirectory {
 
             // Files for starting matches. 'rlbot.cfg' is created right before match start.
             Files.createDirectories(MATCH_FILES);
-            Files.copy(internalPath("settings/files/run.py"), RUN_PY, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(Main.class.getResourceAsStream("settings/files/run.py"), RUN_PY, StandardCopyOption.REPLACE_EXISTING);
 
             setupPsyonixBots();
 
@@ -53,9 +52,9 @@ public class SettingsDirectory {
      */
     private static void setupPsyonixBots() throws IOException {
         Files.createDirectories(PSYONIX_BOTS);
-        FileOperations.copyIfMissing(internalPath("settings/files/psyonix_appearance.cfg"), PSYONIX_APPEARANCE);
-        FileOperations.copyIfMissing(internalPath("settings/files/psyonix_allstar.cfg"), PSYONIX_ALLSTAR);
-        FileOperations.copyIfMissing(internalPath("settings/files/psyonix_pro.cfg"), PSYONIX_PRO);
-        FileOperations.copyIfMissing(internalPath("settings/files/psyonix_rookie.cfg"), PSYONIX_ROOKIE);
+        FileOperations.copyIfMissing(Main.class.getResourceAsStream("settings/files/psyonix_appearance.cfg"), PSYONIX_APPEARANCE);
+        FileOperations.copyIfMissing(Main.class.getResourceAsStream("settings/files/psyonix_allstar.cfg"), PSYONIX_ALLSTAR);
+        FileOperations.copyIfMissing(Main.class.getResourceAsStream("settings/files/psyonix_pro.cfg"), PSYONIX_PRO);
+        FileOperations.copyIfMissing(Main.class.getResourceAsStream("settings/files/psyonix_rookie.cfg"), PSYONIX_ROOKIE);
     }
 }

--- a/src/dk/aau/cs/ds306e18/tournament/utility/FileOperations.java
+++ b/src/dk/aau/cs/ds306e18/tournament/utility/FileOperations.java
@@ -5,6 +5,7 @@ import dk.aau.cs.ds306e18.tournament.model.Tournament;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.file.*;
 
@@ -218,25 +219,20 @@ public class FileOperations {
     }
 
     /**
-     * Creates a Path for an internal file.
-     * @param pathRelToMain a String describing the location of the file relative to Main.java
-     * @return a Path
+     * Copies a file from source to destination, but only if the destination does not exist already.
      */
-    public static Path internalPath(String pathRelToMain) {
-        try {
-            return Paths.get(Main.class.getResource(pathRelToMain).toURI());
-        } catch (URISyntaxException e) {
-            e.printStackTrace();
-            return null;
+    public static void copyIfMissing(Path source, Path destination) throws IOException {
+        if (!Files.exists(destination)) {
+            Files.copy(source, destination);
         }
     }
 
     /**
      * Copies a file from source to destination, but only if the destination does not exist already.
      */
-    public static void copyIfMissing(Path source, Path destination) throws IOException {
+    public static void copyIfMissing(InputStream inputStream, Path destination) throws IOException {
         if (!Files.exists(destination)) {
-            Files.copy(source, destination);
+            Files.copy(inputStream, destination);
         }
     }
 }


### PR DESCRIPTION
It turns out files in a jar does not exist on the file system, which means that nio Paths can't point to them. This was resolved by instead using streams for internal resources, that we want to copy to the settings folder.