### PR TITLE
Improved how round robin decides the top teams of the stage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+#### Unreleased changes
+- Improved how round robin decides the top teams of the stage. #92 - NicEastvillage
+
+
+
 #### Version 1.5.1 - 3. October 2019
 - Added seeding for first round of Swiss. - NicEastvillage
 - Bogded the Swiss round generation algorithm to never make rounds with missing matches. Instead

--- a/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinFormat.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinFormat.java
@@ -58,7 +58,7 @@ public class RoundRobinFormat implements Format, MatchPlayedListener {
     public List<Team> getTopTeams(int count, TieBreaker tieBreaker) {
 
         /*
-        Sort the teams each group by their performance. Then pick the top X teams as follows:
+        Sort the teams of each group by their performance. Then pick the top X teams as follows:
         1st from group 0,
         1st from group 1,
         ...
@@ -66,7 +66,7 @@ public class RoundRobinFormat implements Format, MatchPlayedListener {
         2nd from group 0,
         2nd from group 1,
         ...
-        Until X teams was picked or every team was picked.
+        Until X teams has been picked or every team was picked.
 
         However, the first groups might be smaller if the number of teams is not divisible by the number groups.
         Therefore we skip those when they are empty.

--- a/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinFormat.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinFormat.java
@@ -33,6 +33,7 @@ public class RoundRobinFormat implements Format, MatchPlayedListener {
 
         if (seededTeams.size() <= 1) {
             matches = new ArrayList<>();
+            groups = new ArrayList<>();
             status = StageStatus.CONCLUDED;
 
         } else {
@@ -55,7 +56,48 @@ public class RoundRobinFormat implements Format, MatchPlayedListener {
 
     @Override
     public List<Team> getTopTeams(int count, TieBreaker tieBreaker) {
-        return tieBreaker.compareWithPoints(teams, getTeamPointsMap(), this).subList(0, count);
+
+        /*
+        Sort the teams each group by their performance. Then pick the top X teams as follows:
+        1st from group 0,
+        1st from group 1,
+        ...
+        1st from group N-1,
+        2nd from group 0,
+        2nd from group 1,
+        ...
+        Until X teams was picked or every team was picked.
+
+        However, the first groups might be smaller if the number of teams is not divisible by the number groups.
+        Therefore we skip those when they are empty.
+         */
+
+        HashMap<Team, Integer> pointsMap = getTeamPointsMap();
+        List<List<Team>> sortedGroups = groups.stream()
+                .map((group) -> tieBreaker.compareWithPoints(group.getTeams(), pointsMap, this))
+                .collect(Collectors.toList());
+
+        List<Team> topTeams = new ArrayList<>();
+        int left = Math.min(count, teams.size());
+        int nextGroupToTakeFrom = 0;
+        int indexToTake = 0;
+
+        while (left > 0) {
+            List<Team> group = sortedGroups.get(nextGroupToTakeFrom);
+            // Are there more teams in this group?
+            if (group.size() > indexToTake) {
+                topTeams.add(group.get(indexToTake));
+                left--;
+            }
+            nextGroupToTakeFrom++;
+            if (nextGroupToTakeFrom == groups.size()) {
+                // Wrap around at last group and pick next best team from the groups
+                nextGroupToTakeFrom = 0;
+                indexToTake++;
+            }
+        }
+
+        return topTeams;
     }
 
     /** This function populates the groups list and generates the matches for each group. */

--- a/test/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinFormatTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinFormatTest.java
@@ -189,29 +189,47 @@ public class RoundRobinFormatTest {
     public void getTopTeams02() {
 
         RoundRobinFormat rr = new RoundRobinFormat();
-        List<Team> inputTeams = getTestTeams(4, 2);
-        rr.start(inputTeams, true);
+        List<Team> teams = getTestTeams(7, 1);
+        rr.start(teams, true);
 
-        setAllMatchesToPlayed(rr.getUpcomingMatches());
-        //All teams now have the same amount of points.
+        ArrayList<Team> top4Teams = new ArrayList<>(rr.getTopTeams(4, TieBreaker.SEED));
 
-        ArrayList<Team> top3Teams = new ArrayList<>(rr.getTopTeams(3, TieBreaker.SEED));
+        // Should match seeds when all have the same amount of points
+        assertEquals(teams.get(0), top4Teams.get(0));
+        assertEquals(teams.get(1), top4Teams.get(1));
+        assertEquals(teams.get(2), top4Teams.get(2));
+        assertEquals(teams.get(3), top4Teams.get(3));
+    }
 
-        //Get the team not in the top3Teams list
-        ArrayList<Team> teamInputCopy = new ArrayList<>(inputTeams);
-        Team notInTopTeam;
-        for (Team top3Team : top3Teams) {
-            teamInputCopy.remove(top3Team);
+    @Test
+    public void getTopTeams03() {
+
+        RoundRobinFormat rr = new RoundRobinFormat();
+        List<Team> teams = getTestTeams(8, 1);
+        rr.setNumberOfGroups(3); // group sizes: 2, 3, 3
+        rr.start(teams, true);
+
+        // Assign goals equal to their seed, i.e. expected winner loses
+        for (Match m : rr.getUpcomingMatches()) {
+            int teamOneSeed = m.getTeamOne().getInitialSeedValue();
+            int teamTwoSeed = m.getTeamTwo().getInitialSeedValue();
+            m.setScores(teamOneSeed, teamTwoSeed, true);
         }
-        notInTopTeam = teamInputCopy.get(0);
 
-        //
-        HashMap<Team, Integer> teamPoints = rr.getTeamPointsMap();
-        Team top3Team = top3Teams.get(2);
-        Integer top3TeamPoints = teamPoints.get(top3Team);
-        Integer notInTopTeamPoints = teamPoints.get(notInTopTeam);
-        assertTrue(top3TeamPoints >= notInTopTeamPoints &&
-                top3Team.getInitialSeedValue() <= notInTopTeam.getInitialSeedValue());
+        ArrayList<Team> top7Teams = new ArrayList<>(rr.getTopTeams(7, TieBreaker.SEED));
+
+        // We expect:
+        // 2 from group 0
+        // 3 from group 1
+        // 2 grom group 2
+        // And team 3 won't proceed as it is the loser of the last group
+        assertEquals(teams.get(3), top7Teams.get(0));
+        assertEquals(teams.get(6), top7Teams.get(1));
+        assertEquals(teams.get(7), top7Teams.get(2));
+        assertEquals(teams.get(0), top7Teams.get(3));
+        assertEquals(teams.get(4), top7Teams.get(4));
+        assertEquals(teams.get(5), top7Teams.get(5));
+        assertEquals(teams.get(1), top7Teams.get(6));
     }
 
     @Test


### PR DESCRIPTION
Now sort the teams of each group by their performance. Then pick the top X teams as follows:
1st from group 0,
1st from group 1,
...
1st from group N-1,
2nd from group 0,
2nd from group 1,
...
Until X teams has been picked or every team was picked.
However, the first groups might be smaller if the number of teams is not divisible by the number groups. Therefore we skip those when they are empty.

Resolves #92 