### PR TITLE
Improved RLBot Runner process so that it doesn't have to be shut down after each match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ gradle-app.setting
 
 # Cache of project
 .gradletasknamecache
+
+# Overlay data
+current_match.json

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,12 @@
 
 #### Unreleased Changes
 - Now writes overlay data to a json next to the cleopetra.jar. This can be disabled in RLBotSettings tab. - NicEastvillage
-
+- Improved the RLBot runner process. - NicEastvillage
+    - The RLBot console window (RLBot runner) now does not need to be shut down after each match. #88
+    - CleoPetra issues the RLBot runner to start and stop new matches through socket communication.
+    - RLBot.exe is not shut down between each match, which means:
+        - Skyborg's overlay will work properly.
+        - Rendering and bot percentages does not have to be toggled each match.
 
 
 #### Version 1.5.1 - 3. October 2019

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+#### Unreleased Changes
+- Now writes overlay data to a json next to the cleopetra.jar. This can be disabled in RLBotSettings tab. - NicEastvillage
+
+
+
 #### Version 1.5.1 - 3. October 2019
 - Added seeding for first round of Swiss. - NicEastvillage
 - Bogded the Swiss round generation algorithm to never make rounds with missing matches. Instead

--- a/src/dk/aau/cs/ds306e18/tournament/model/match/Match.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/match/Match.java
@@ -585,6 +585,13 @@ public final class Match {
         }
     }
 
+    /**
+     * Returns true if the match is currently playable and both teams consists of one bot.
+     */
+    public boolean isOneVsOne() {
+        return (isReadyToPlay() && teamOne.size() == 1 && teamTwo.size() == 1);
+    }
+
     public int getTeamOneScore() {
         return teamOneScore;
     }

--- a/src/dk/aau/cs/ds306e18/tournament/rlbot/MatchRunner.java
+++ b/src/dk/aau/cs/ds306e18/tournament/rlbot/MatchRunner.java
@@ -10,15 +10,44 @@ import dk.aau.cs.ds306e18.tournament.settings.SettingsDirectory;
 import dk.aau.cs.ds306e18.tournament.utility.Alerts;
 
 import java.io.*;
+import java.net.ConnectException;
+import java.net.Socket;
 import java.nio.file.Path;
 import java.util.ArrayList;
 
+/**
+ * This class maintains a RLBot runner process for starting matches. The runner process is the run.py running in
+ * a separate command prompt. Communication between CleoPetra and the RLBot runner happens through a socket and
+ * consists of simple commands like STOP, STOP, EXIT, which are defined in the subclass Command. If the RLBot runner
+ * is not running when a command is issued, a new instance of the RLBot runner is started.
+ */
 public class MatchRunner {
 
     // The first %s will be replaced with the directory of the rlbot.cfg. The second %s will be the drive 'C:' to change drive.
     private static final String COMMAND_FORMAT = "cmd.exe /c start cmd /c \"cd %s & %s & python run.py\"";
+    private static final String ADDR = "127.0.0.1";
+    private static final int PORT = 35353; // TODO Make user able to change the port in a settings file
 
-    /** Starts the given match in Rocket League. */
+    private enum Command {
+        START("START"), // Start the match described by the rlbot.cfg
+        STOP("STOP"), // Stop the current match and all bot pids
+        EXIT("EXIT"); // Close the run.py process
+
+        private final String cmd;
+
+        Command(String cmd) {
+            this.cmd = cmd;
+        }
+
+        @Override
+        public String toString() {
+            return cmd;
+        }
+    }
+
+    /**
+     * Starts the given match in Rocket League.
+     */
     public static boolean startMatch(MatchConfig matchConfig, Match match) {
 
         // Checks settings and modifies rlbot.cfg file if everything is okay
@@ -27,21 +56,60 @@ public class MatchRunner {
             return false;
         }
 
+        return sendCommandToRLBot(Command.START, true);
+    }
+
+    /**
+     * Start the RLBot runner in the run.py and will be a separate process in a separate cmd.
+     * The runner might not be ready to accept commands immediately. This method returns true on success.
+     */
+    private static boolean startRLBotRunner() {
         try {
+            Alerts.infoNotification("Starting RLBot runner", "Attempting to start new instance of run.py for running matches.");
             Path pathToDirectory = SettingsDirectory.RUN_PY.getParent();
-            String command = String.format(COMMAND_FORMAT, pathToDirectory, pathToDirectory.toString().substring(0, 2));
-            System.out.println("Starting RLBot framework with command: " + command);
-            Runtime.getRuntime().exec(command);
+            String cmd = String.format(COMMAND_FORMAT, pathToDirectory, pathToDirectory.toString().substring(0, 2));
+            Runtime.getRuntime().exec(cmd);
             return true;
-
-        } catch (Exception err) {
-            err.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+            Alerts.errorNotification("Could not start RLBot runner", "Something went wrong starting the run.py.");
+            return false;
         }
+    }
 
+    /**
+     * Sends the given command to the RLBot runner. If the runner does not respond, this method will optionally
+     * start a new RLBot runner instance and retry sending the command. If we believe the command was send
+     * and received, this method returns true, otherwise false.
+     */
+    private static boolean sendCommandToRLBot(Command cmd, boolean startRLBotIfMissingAndRetry) {
+        try (Socket sock = new Socket(ADDR, PORT);
+             PrintWriter writer = new PrintWriter(sock.getOutputStream(), true)) {
+            writer.print(cmd.toString());
+            writer.flush();
+            return true;
+        } catch (ConnectException e) {
+            // The run.py did not respond. Starting a new instance if allowed
+            if (startRLBotIfMissingAndRetry) {
+                try {
+                    startRLBotRunner();
+                    Thread.sleep(200);
+                    // Retry
+                    return sendCommandToRLBot(cmd, false);
+                } catch (InterruptedException ex) {
+                    ex.printStackTrace();
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            Alerts.errorNotification("IO Exception", "Failed to open socket and send message to run.py");
+        }
         return false;
     }
 
-    /** Returns true if the given match can be started. */
+    /**
+     * Returns true if the given match can be started.
+     */
     public static boolean canStartMatch(Match match) {
         try {
             checkMatch(match);

--- a/src/dk/aau/cs/ds306e18/tournament/rlbot/MatchRunner.java
+++ b/src/dk/aau/cs/ds306e18/tournament/rlbot/MatchRunner.java
@@ -74,10 +74,10 @@ public class MatchRunner {
     }
 
     /**
-     * Start the RLBot runner in the run.py and will be a separate process in a separate cmd.
+     * Starts the RLBot runner, aka. the run.py, as a separate process in a separate cmd.
      * The runner might not be ready to accept commands immediately. This method returns true on success.
      */
-    private static boolean startRLBotRunner() {
+    public static boolean startRLBotRunner() {
         try {
             Alerts.infoNotification("Starting RLBot runner", "Attempting to start new instance of run.py for running matches.");
             Path pathToDirectory = SettingsDirectory.RUN_PY.getParent();
@@ -89,6 +89,21 @@ public class MatchRunner {
             Alerts.errorNotification("Could not start RLBot runner", "Something went wrong starting the run.py.");
             return false;
         }
+    }
+
+    /**
+     * Closes the RLBot runner.
+     */
+    public static void closeRLBotRunner() {
+        // If the command fails, the runner is probably not running anyway, so ignore any errors.
+        sendCommandToRLBot(Command.EXIT, false);
+    }
+
+    /**
+     * Stops the current match.
+     */
+    public static void stopMatch() {
+        sendCommandToRLBot(Command.STOP, false);
     }
 
     /**

--- a/src/dk/aau/cs/ds306e18/tournament/rlbot/MatchRunner.java
+++ b/src/dk/aau/cs/ds306e18/tournament/rlbot/MatchRunner.java
@@ -2,16 +2,20 @@ package dk.aau.cs.ds306e18.tournament.rlbot;
 
 import dk.aau.cs.ds306e18.tournament.model.Bot;
 import dk.aau.cs.ds306e18.tournament.model.BotFromConfig;
+import dk.aau.cs.ds306e18.tournament.model.Tournament;
 import dk.aau.cs.ds306e18.tournament.model.match.Match;
 import dk.aau.cs.ds306e18.tournament.rlbot.configuration.MatchConfig;
 import dk.aau.cs.ds306e18.tournament.rlbot.configuration.ParticipantInfo;
 import dk.aau.cs.ds306e18.tournament.rlbot.configuration.TeamColor;
 import dk.aau.cs.ds306e18.tournament.settings.SettingsDirectory;
 import dk.aau.cs.ds306e18.tournament.utility.Alerts;
+import dk.aau.cs.ds306e18.tournament.utility.OverlayData;
 
 import java.io.*;
 import java.net.ConnectException;
 import java.net.Socket;
+import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 
@@ -54,6 +58,16 @@ public class MatchRunner {
         boolean ready = prepareMatch(matchConfig, match);
         if (!ready) {
             return false;
+        }
+
+        // Write overlay data to current_match.json
+        if (Tournament.get().getRlBotSettings().writeOverlayData()) {
+            try {
+                OverlayData.write(match);
+            } catch (IOException e) {
+                Alerts.errorNotification("Could not write overlay data", "Failed to write overlay data to " + OverlayData.CURRENT_MATCH_PATH);
+                e.printStackTrace();
+            }
         }
 
         return sendCommandToRLBot(Command.START, true);
@@ -137,9 +151,15 @@ public class MatchRunner {
         if (match.getBlueTeam() == null) throw new IllegalStateException("There is no blue team for this match.");
         if (match.getOrangeTeam() == null) throw new IllegalStateException("There is no orange team for this match.");
 
+        ArrayList<Bot> blueBots = match.getBlueTeam().getBots();
+        ArrayList<Bot> orangeBots = match.getOrangeTeam().getBots();
+
+        if (blueBots.size() == 0) throw new IllegalStateException("There are no bots on the blue team.");
+        if (orangeBots.size() == 0) throw new IllegalStateException("There are no bots on the orange team.");
+
         ArrayList<Bot> bots = new ArrayList<>();
-        bots.addAll(match.getBlueTeam().getBots());
-        bots.addAll(match.getOrangeTeam().getBots());
+        bots.addAll(blueBots);
+        bots.addAll(orangeBots);
 
         for (Bot bot : bots) {
             String path = bot.getConfigPath();

--- a/src/dk/aau/cs/ds306e18/tournament/rlbot/RLBotSettings.java
+++ b/src/dk/aau/cs/ds306e18/tournament/rlbot/RLBotSettings.java
@@ -4,12 +4,16 @@ import dk.aau.cs.ds306e18.tournament.rlbot.configuration.MatchConfig;
 
 import java.util.Objects;
 
+/**
+ * Settings related to the tournament or RLBot
+ */
 public class RLBotSettings {
 
-    private MatchConfig matchConfig;
+    private MatchConfig matchConfig = new MatchConfig();
+    private boolean writeOverlayData = true;
 
     public RLBotSettings() {
-        this(new MatchConfig());
+
     }
 
     public RLBotSettings(MatchConfig matchConfig) {
@@ -24,16 +28,25 @@ public class RLBotSettings {
         this.matchConfig = matchConfig;
     }
 
+    public boolean writeOverlayData() {
+        return writeOverlayData;
+    }
+
+    public void setWriteOverlayData(boolean writeOverlayData) {
+        this.writeOverlayData = writeOverlayData;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RLBotSettings that = (RLBotSettings) o;
-        return Objects.equals(matchConfig, that.matchConfig);
+        return writeOverlayData == that.writeOverlayData &&
+                Objects.equals(matchConfig, that.matchConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(matchConfig);
+        return Objects.hash(matchConfig, writeOverlayData);
     }
 }

--- a/src/dk/aau/cs/ds306e18/tournament/settings/files/run.py
+++ b/src/dk/aau/cs/ds306e18/tournament/settings/files/run.py
@@ -101,4 +101,4 @@ if __name__ == '__main__':
         print("Press enter to close.")
         input()
     finally:
-        print("run.py stopped")
+        print("run.py stopped. You can close this!")

--- a/src/dk/aau/cs/ds306e18/tournament/settings/files/run.py
+++ b/src/dk/aau/cs/ds306e18/tournament/settings/files/run.py
@@ -1,10 +1,86 @@
+import time
+import socket
+from threading import Event, Thread
+
+from rlbot.setup_manager import SetupManager, setup_manager_context
+
+
+PORT = 35353
+
+
+def setup_match(manager: SetupManager):
+    manager.shut_down(kill_all_pids=True, quiet=True)  # Stop any running pids
+    manager.load_config()
+    manager.launch_early_start_bot_processes()
+    manager.start_match()
+    manager.launch_bot_processes()
+
+
+def wait_for_all_bots(manager: SetupManager):
+    while not manager.has_received_metadata_from_all_bots():
+        manager.try_recieve_agent_metadata()
+        time.sleep(0.1)
+
+
+def start_match(manager: SetupManager):
+    game_interface = manager.game_interface
+    setup_match(manager)
+    wait_for_all_bots(manager)
+
+
+def stop_match(manager: SetupManager):
+    manager.shut_down(kill_all_pids=True, quiet=True)
+
+
+def match_running(start_event: Event, stop_event: Event):
+    with setup_manager_context() as manager:
+        while True:
+            if start_event.is_set():
+                start_match(manager)
+                start_event.clear()
+            elif stop_event.is_set():
+                stop_match(manager)
+                stop_event.clear()
+
+
 if __name__ == '__main__':
+    print("""/<<<<<<<<<<<<<<<<<<<o>>>>>>>>>>>>>>>>>>>\\
+| Hello! I am CleoPetra's little helper |
+| and your view into the RLBot process. |
+| Keep me open while using CleoPetra!   |
+\\<<<<<<<<<<<<<<<<<<<o>>>>>>>>>>>>>>>>>>>/
+""")
 
     try:
-        from rlbot import runner
-        runner.main()
+        start_event = Event()
+        stop_event = Event()
+
+        #Thread(args=(start_event, stop_event)).start()
+
+        # AF_INET is the Internet address family for IPv4. SOCK_STREAM is the socket type for TCP
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(('127.0.0.1', PORT))
+            s.listen()
+            print(f"Listening for CleoPetra on 127.0.0.1:{PORT} ...")
+            while True:
+                conn, addr = s.accept()
+                with conn:
+                    print('Connected by', addr)
+                    data = conn.recv(1024)
+                    if data == b"START":
+                        print("Starting match!")
+                    elif data == b"STOP":
+                        print("Stopping match!")
+                    elif data == b"QUIT":
+                        print("Quiting!")
+                        break
+                    else:
+                        print(f"Other message: {data}")
+                    conn.sendall(b'Gotcha from Python!')
 
     except Exception as e:
         print("Encountered exception: ", e)
         print("Press enter to close.")
         input()
+    finally:
+        print("run.py stopped")

--- a/src/dk/aau/cs/ds306e18/tournament/settings/files/run.py
+++ b/src/dk/aau/cs/ds306e18/tournament/settings/files/run.py
@@ -8,6 +8,12 @@ from rlbot.setup_manager import SetupManager, setup_manager_context
 PORT = 35353
 
 
+class Command:
+    START = b"START"
+    STOP = b"STOP"
+    EXIT = b"EXIT"
+
+
 def setup_match(manager: SetupManager):
     manager.shut_down(kill_all_pids=True, quiet=True)  # Stop any running pids
     manager.load_config()
@@ -32,7 +38,7 @@ def stop_match(manager: SetupManager):
     manager.shut_down(kill_all_pids=True, quiet=True)
 
 
-def match_running(start_event: Event, stop_event: Event):
+def match_running(start_event: Event, stop_event: Event, exit_event: Event):
     with setup_manager_context() as manager:
         while True:
             if start_event.is_set():
@@ -41,6 +47,9 @@ def match_running(start_event: Event, stop_event: Event):
             elif stop_event.is_set():
                 stop_match(manager)
                 stop_event.clear()
+            elif exit_event.is_set():
+                exit_event.clear()
+                break
 
 
 if __name__ == '__main__':
@@ -54,8 +63,10 @@ if __name__ == '__main__':
     try:
         start_event = Event()
         stop_event = Event()
+        exit_event = Event()
 
-        #Thread(args=(start_event, stop_event)).start()
+        match_runner = Thread(target=match_running, args=(start_event, stop_event, exit_event))
+        match_runner.start()
 
         # AF_INET is the Internet address family for IPv4. SOCK_STREAM is the socket type for TCP
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -67,16 +78,23 @@ if __name__ == '__main__':
                 with conn:
                     print('Connected by', addr)
                     data = conn.recv(1024)
-                    if data == b"START":
+
+                    if data == Command.START:
                         print("Starting match!")
-                    elif data == b"STOP":
+                        start_event.set()
+                    elif data == Command.STOP:
                         print("Stopping match!")
-                    elif data == b"QUIT":
-                        print("Quiting!")
+                        stop_event.set()
+                    elif data == Command.EXIT:
+                        print("Exiting!")
+                        exit_event.set()
                         break
                     else:
-                        print(f"Other message: {data}")
-                    conn.sendall(b'Gotcha from Python!')
+                        print(f"Unknown command received: {data}")
+
+                    conn.sendall(b'Gotcha!')
+
+        match_runner.join()
 
     except Exception as e:
         print("Encountered exception: ", e)

--- a/src/dk/aau/cs/ds306e18/tournament/ui/RLBotSettingsTabController.java
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/RLBotSettingsTabController.java
@@ -1,6 +1,7 @@
 package dk.aau.cs.ds306e18.tournament.ui;
 
 import dk.aau.cs.ds306e18.tournament.model.Tournament;
+import dk.aau.cs.ds306e18.tournament.rlbot.MatchRunner;
 import dk.aau.cs.ds306e18.tournament.rlbot.RLBotSettings;
 import dk.aau.cs.ds306e18.tournament.rlbot.configuration.MatchConfig;
 import dk.aau.cs.ds306e18.tournament.rlbot.configuration.MatchConfigOptions;
@@ -26,6 +27,9 @@ public class RLBotSettingsTabController {
     public RadioButton skipReplaysRadioButton;
     public RadioButton instantStartRadioButton;
     public RadioButton writeOverlayDataRadioButton;
+    public Button rlbotRunnerOpenButton;
+    public Button rlbotRunnerCloseButton;
+    public Button rlbotRunnerStopMatchButton;
     public ChoiceBox<MatchLength> matchLengthChoiceBox;
     public ChoiceBox<MaxScore> maxScoreChoiceBox;
     public ChoiceBox<Overtime> overtimeChoiceBox;
@@ -136,5 +140,17 @@ public class RLBotSettingsTabController {
 
         // Other settings
         writeOverlayDataRadioButton.setSelected(settings.writeOverlayData());
+    }
+
+    public void onActionRLBotRunnerOpen(ActionEvent actionEvent) {
+        MatchRunner.startRLBotRunner();
+    }
+
+    public void onActionRLBotRunnerClose(ActionEvent actionEvent) {
+        MatchRunner.closeRLBotRunner();
+    }
+
+    public void onActionRLBotRunnerStopMatch(ActionEvent actionEvent) {
+        MatchRunner.stopMatch();
     }
 }

--- a/src/dk/aau/cs/ds306e18/tournament/ui/RLBotSettingsTabController.java
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/RLBotSettingsTabController.java
@@ -1,6 +1,7 @@
 package dk.aau.cs.ds306e18.tournament.ui;
 
 import dk.aau.cs.ds306e18.tournament.model.Tournament;
+import dk.aau.cs.ds306e18.tournament.rlbot.RLBotSettings;
 import dk.aau.cs.ds306e18.tournament.rlbot.configuration.MatchConfig;
 import dk.aau.cs.ds306e18.tournament.rlbot.configuration.MatchConfigOptions;
 import dk.aau.cs.ds306e18.tournament.rlbot.configuration.MatchConfigOptions.*;
@@ -24,6 +25,7 @@ public class RLBotSettingsTabController {
     public ChoiceBox<GameMode> gameModeChoiceBox;
     public RadioButton skipReplaysRadioButton;
     public RadioButton instantStartRadioButton;
+    public RadioButton writeOverlayDataRadioButton;
     public ChoiceBox<MatchLength> matchLengthChoiceBox;
     public ChoiceBox<MaxScore> maxScoreChoiceBox;
     public ChoiceBox<Overtime> overtimeChoiceBox;
@@ -46,7 +48,8 @@ public class RLBotSettingsTabController {
     private void initialize() {
         instance = this;
 
-        MatchConfig matchConfig = Tournament.get().getRlBotSettings().getMatchConfig();
+        RLBotSettings settings = Tournament.get().getRlBotSettings();
+        MatchConfig matchConfig = settings.getMatchConfig();
 
         // General match settings
         setupChoiceBox(gameMapChoiceBox, GameMap.values(), matchConfig.getGameMap(), MatchConfig::setGameMap);
@@ -77,6 +80,12 @@ public class RLBotSettingsTabController {
         setupChoiceBox(demolishChoiceBox, Demolish.values(), matchConfig.getDemolish(), MatchConfig::setDemolish);
         setupChoiceBox(respawnTimeChoiceBox, RespawnTime.values(), matchConfig.getRespawnTime(), MatchConfig::setRespawnTime);
 
+        // Other settings
+        writeOverlayDataRadioButton.setSelected(settings.writeOverlayData());
+        writeOverlayDataRadioButton.selectedProperty().addListener((observable, oldValue, newValue) -> {
+            Tournament.get().getRlBotSettings().setWriteOverlayData(newValue);
+        });
+
         update();
     }
 
@@ -99,7 +108,8 @@ public class RLBotSettingsTabController {
     /** Updates all ui elements */
     public void update() {
 
-        MatchConfig matchConfig = Tournament.get().getRlBotSettings().getMatchConfig();
+        RLBotSettings settings = Tournament.get().getRlBotSettings();
+        MatchConfig matchConfig = settings.getMatchConfig();
 
         // General match settings
         gameMapChoiceBox.getSelectionModel().select(matchConfig.getGameMap());
@@ -123,5 +133,8 @@ public class RLBotSettingsTabController {
         gravityChoiceBox.getSelectionModel().select(matchConfig.getGravity());
         demolishChoiceBox.getSelectionModel().select(matchConfig.getDemolish());
         respawnTimeChoiceBox.getSelectionModel().select(matchConfig.getRespawnTime());
+
+        // Other settings
+        writeOverlayDataRadioButton.setSelected(settings.writeOverlayData());
     }
 }

--- a/src/dk/aau/cs/ds306e18/tournament/ui/layout/BracketOverviewTab.fxml
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/layout/BracketOverviewTab.fxml
@@ -15,7 +15,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<GridPane id="mainGrid" fx:id="bracketOverviewTab" prefHeight="572.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dk.aau.cs.ds306e18.tournament.ui.BracketOverviewTabController">
+<GridPane id="mainGrid" fx:id="bracketOverviewTab" prefHeight="720.0" prefWidth="1080.0" xmlns="http://javafx.com/javafx/1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dk.aau.cs.ds306e18.tournament.ui.BracketOverviewTabController">
    <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
       <ColumnConstraints hgrow="SOMETIMES" maxWidth="300.0" minWidth="10.0" prefWidth="100.0" />

--- a/src/dk/aau/cs/ds306e18/tournament/ui/layout/RLBotSettingsTab.fxml
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/layout/RLBotSettingsTab.fxml
@@ -4,6 +4,7 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.RadioButton?>
+<?import javafx.scene.control.Separator?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
@@ -100,6 +101,29 @@
                            </font>
                         </Text>
                         <RadioButton fx:id="instantStartRadioButton" mnemonicParsing="false" GridPane.columnIndex="1" />
+                     </children>
+                  </GridPane>
+                  <Separator prefWidth="200.0" />
+                  <Text layoutX="30.0" layoutY="126.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Other">
+                     <font>
+                        <Font name="System Bold" size="16.0" />
+                     </font>
+                  </Text>
+                  <GridPane layoutX="30.0" layoutY="215.0">
+                     <columnConstraints>
+                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+                        <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" minWidth="10.0" />
+                     </columnConstraints>
+                     <rowConstraints>
+                        <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+                     </rowConstraints>
+                     <children>
+                        <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Write overlay data:">
+                           <font>
+                              <Font size="16.0" />
+                           </font>
+                        </Text>
+                        <RadioButton fx:id="writeOverlayDataRadioButton" layoutX="494.0" layoutY="13.0" mnemonicParsing="false" GridPane.columnIndex="1" />
                      </children>
                   </GridPane>
                </children>

--- a/src/dk/aau/cs/ds306e18/tournament/ui/layout/RLBotSettingsTab.fxml
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/layout/RLBotSettingsTab.fxml
@@ -126,6 +126,32 @@
                         <RadioButton fx:id="writeOverlayDataRadioButton" layoutX="494.0" layoutY="13.0" mnemonicParsing="false" GridPane.columnIndex="1" />
                      </children>
                   </GridPane>
+                  <Separator layoutX="30.0" layoutY="279.0" prefWidth="200.0" />
+                  <Text layoutX="30.0" layoutY="309.0" strokeType="OUTSIDE" strokeWidth="0.0" text="RLBot Runner">
+                     <font>
+                        <Font name="System Bold" size="16.0" />
+                     </font>
+                  </Text>
+                  <Text strokeType="OUTSIDE" strokeWidth="0.0" text="CleoPetra's little helper for running matches.&#10;It will be open automatically if missing.&#10;Rocket League will also be opened, when the RLBot Runner is opened.">
+                     <font>
+                        <Font size="14.0" />
+                     </font>
+                  </Text>
+                  <GridPane hgap="8.0" maxHeight="-Infinity" maxWidth="-Infinity">
+                    <columnConstraints>
+                      <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                    </columnConstraints>
+                    <rowConstraints>
+                      <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+                    </rowConstraints>
+                     <children>
+                        <Button fx:id="rlbotRunnerOpenButton" mnemonicParsing="false" onAction="#onActionRLBotRunnerOpen" prefHeight="27.0" prefWidth="101.0" text="Open" />
+                        <Button fx:id="rlbotRunnerCloseButton" layoutX="10.0" layoutY="10.0" mnemonicParsing="false" onAction="#onActionRLBotRunnerClose" prefHeight="27.0" prefWidth="101.0" text="Close" GridPane.columnIndex="1" />
+                        <Button fx:id="rlbotRunnerStopMatchButton" layoutX="10.0" layoutY="10.0" mnemonicParsing="false" onAction="#onActionRLBotRunnerStopMatch" prefHeight="27.0" prefWidth="101.0" text="Stop match" GridPane.columnIndex="2" />
+                     </children>
+                  </GridPane>
                </children>
                <padding>
                   <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />

--- a/src/dk/aau/cs/ds306e18/tournament/utility/Alerts.java
+++ b/src/dk/aau/cs/ds306e18/tournament/utility/Alerts.java
@@ -22,7 +22,7 @@ public class Alerts {
                 .title(title)
                 .text(text)
                 .graphic(null)
-                .hideAfter(Duration.seconds(3))
+                .hideAfter(Duration.seconds(5))
                 .position(Pos.BOTTOM_RIGHT)
                 .owner(window)
                 .showInformation();
@@ -38,7 +38,7 @@ public class Alerts {
                 .title(title)
                 .text(text)
                 .graphic(null)
-                .hideAfter(Duration.seconds(5))
+                .hideAfter(Duration.seconds(8))
                 .position(Pos.BOTTOM_RIGHT)
                 .owner(window)
                 .showError();

--- a/src/dk/aau/cs/ds306e18/tournament/utility/OverlayData.java
+++ b/src/dk/aau/cs/ds306e18/tournament/utility/OverlayData.java
@@ -1,0 +1,55 @@
+package dk.aau.cs.ds306e18.tournament.utility;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import dk.aau.cs.ds306e18.tournament.model.Bot;
+import dk.aau.cs.ds306e18.tournament.model.BotFromConfig;
+import dk.aau.cs.ds306e18.tournament.model.match.Match;
+import dk.aau.cs.ds306e18.tournament.rlbot.configuration.BotConfig;
+import dk.aau.cs.ds306e18.tournament.serialization.Serializer;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * A data class for the RLBot's current OBS overlay script
+ */
+public class OverlayData {
+
+    public static final Path CURRENT_MATCH_PATH = Paths.get("current_match.json").toAbsolutePath();
+
+    @SerializedName("division")
+    private final int division = 0; // Not used
+
+    @SerializedName("blue_config_path")
+    private final String blueConfig;
+
+    @SerializedName("orange_config_path")
+    private final String orangeConfig;
+
+    public OverlayData(BotConfig blueConfig, BotConfig orangeConfig) {
+        this.blueConfig = blueConfig.getConfigFile().getAbsolutePath();
+        this.orangeConfig = orangeConfig.getConfigFile().getAbsolutePath();
+    }
+
+    /**
+     * Write the overlay data to the default location. Aborts with no exception if the match is not 1v1 or
+     * not ready to be played or if one of the bots are not a bot from a config file.
+     */
+    public static void write(Match match) throws IOException {
+        if (match.isOneVsOne()) {
+            Bot blueBot = match.getBlueTeam().getBots().get(0);
+            Bot orangeBot = match.getOrangeTeam().getBots().get(0);
+            if (blueBot instanceof BotFromConfig && orangeBot instanceof BotFromConfig) {
+                OverlayData overlayData = new OverlayData(
+                        ((BotFromConfig) blueBot).getConfig(),
+                        ((BotFromConfig) orangeBot).getConfig()
+                );
+                Serializer.gson.toJson(overlayData);
+                Files.write(CURRENT_MATCH_PATH, new Gson().toJson(overlayData).getBytes());
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fixes one of the biggest non-automated things right now, #88.
Changes:
- The RLBot console window (RLBot runner) now does not need to be manually shut down after each match, which makes life to much easier for the tournament host.
- CleoPetra issues the RLBot runner to start and stop new matches through socket communication. Current commands are:
  - `START`: Starts the match described in the rlbot.cfg (current always updated right before starting a match).
  - `STOP`: Stops the current match and all bot processes.
  - `EXIT`: Closes the RLBot runner process.
- The RLBot Settings tab includes three buttons for the RLBot runner process: Open, Close, and Stop match.
- If the RLBot runner process is not running when a the user attempts to start a match, the runner will be automatically started.
- Since the RLBot.exe is not shut down between each match:
  - Skyborg's overlay will work properly.
  - Rendering and bot percentages does not have to be toggled each match.

Resolves #88

This PR includes the changes in PR #91 to avoid some merge conflicts.

-----

RLBot runner process when opened (also starts and connects to RL):
![billede](https://user-images.githubusercontent.com/21122471/66701032-8d1bd700-ecf7-11e9-896e-a8d6000a1e58.png)

New buttons in settings tab:
![billede](https://user-images.githubusercontent.com/21122471/66701021-6cec1800-ecf7-11e9-9dd9-4b5b6fc4e19a.png)
