### PR TITLE
Option to use RLBotPack's Python installation if available

### DIFF
--- a/src/dk/aau/cs/ds306e18/tournament/rlbot/MatchRunner.java
+++ b/src/dk/aau/cs/ds306e18/tournament/rlbot/MatchRunner.java
@@ -27,8 +27,10 @@ import java.util.ArrayList;
  */
 public class MatchRunner {
 
-    // The first %s will be replaced with the directory of the rlbot.cfg. The second %s will be the drive 'C:' to change drive.
-    private static final String COMMAND_FORMAT = "cmd.exe /c start cmd /c \"cd %s & %s & python run.py\"";
+    // The first %s will be replaced with the directory of the rlbot.cfg.
+    // The second %s will be the drive 'C:' to change drive.
+    // The third %s is the python installation path.
+    private static final String COMMAND_FORMAT = "cmd.exe /c start cmd /c \"cd %s & %s & %s run.py\"";
     private static final String ADDR = "127.0.0.1";
     private static final int PORT = 35353; // TODO Make user able to change the port in a settings file
 
@@ -79,10 +81,19 @@ public class MatchRunner {
      */
     public static boolean startRLBotRunner() {
         try {
-            // TODO; does not support Linux, refactor when relevant
             Alerts.infoNotification("Starting RLBot runner", "Attempting to start new instance of run.py for running matches.");
+
+            String python = "python";
+            if (Tournament.get().getRlBotSettings().useBotPackPythonIfAvailable()) {
+                Path botPackPython = RLBotPack.getPathToPython();
+                if (botPackPython != null) {
+                    python = botPackPython.toString();
+                }
+            }
+
             Path pathToDirectory = SettingsDirectory.RUN_PY.getParent();
-            String cmd = String.format(COMMAND_FORMAT, pathToDirectory, pathToDirectory.toString().substring(0, 2));
+            String cmd = String.format(COMMAND_FORMAT, pathToDirectory, pathToDirectory.toString().substring(0, 2), python);
+            System.out.println("Running command: " + cmd);
             Runtime.getRuntime().exec(cmd);
             return true;
         } catch (IOException e) {

--- a/src/dk/aau/cs/ds306e18/tournament/rlbot/RLBotPack.java
+++ b/src/dk/aau/cs/ds306e18/tournament/rlbot/RLBotPack.java
@@ -17,4 +17,17 @@ public class RLBotPack {
             return null;
         }
     }
+
+    /**
+     * @return The path to the Python installation that the RLBotPack uses. It is not guaranteed to
+     * exist and can be null if APPDATA is not an environment variable.
+     */
+    public static Path getPathToPython() {
+        try {
+            return Paths.get(System.getenv("APPDATA")).getParent().resolve("Local\\RLBotGUI\\Python\\python.exe");
+        } catch (Exception e) {
+            // Failed. Maybe we are on a Linux system
+            return null;
+        }
+    }
 }

--- a/src/dk/aau/cs/ds306e18/tournament/rlbot/RLBotSettings.java
+++ b/src/dk/aau/cs/ds306e18/tournament/rlbot/RLBotSettings.java
@@ -11,6 +11,7 @@ public class RLBotSettings {
 
     private MatchConfig matchConfig = new MatchConfig();
     private boolean writeOverlayData = true;
+    private boolean useBotPackPythonIfAvailable = true;
 
     public RLBotSettings() {
 
@@ -34,6 +35,14 @@ public class RLBotSettings {
 
     public void setWriteOverlayData(boolean writeOverlayData) {
         this.writeOverlayData = writeOverlayData;
+    }
+
+    public boolean useBotPackPythonIfAvailable() {
+        return useBotPackPythonIfAvailable;
+    }
+
+    public void setUseBotPackPythonIfAvailable(boolean useBotPackPythonIfAvailable) {
+        this.useBotPackPythonIfAvailable = useBotPackPythonIfAvailable;
     }
 
     @Override

--- a/src/dk/aau/cs/ds306e18/tournament/ui/RLBotSettingsTabController.java
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/RLBotSettingsTabController.java
@@ -24,6 +24,7 @@ public class RLBotSettingsTabController {
     public RadioButton skipReplaysRadioButton;
     public RadioButton instantStartRadioButton;
     public RadioButton writeOverlayDataRadioButton;
+    public RadioButton useRLBotPackPythonRadioButton;
     public Button rlbotRunnerOpenButton;
     public Button rlbotRunnerCloseButton;
     public Button rlbotRunnerStopMatchButton;
@@ -85,6 +86,10 @@ public class RLBotSettingsTabController {
         writeOverlayDataRadioButton.setSelected(settings.writeOverlayDataEnabled());
         writeOverlayDataRadioButton.selectedProperty().addListener((observable, oldValue, newValue) -> {
             Tournament.get().getRlBotSettings().setWriteOverlayData(newValue);
+        });
+        useRLBotPackPythonRadioButton.setSelected(settings.useBotPackPythonIfAvailable());
+        useRLBotPackPythonRadioButton.selectedProperty().addListener((observable, oldValue, newValue) -> {
+            Tournament.get().getRlBotSettings().setUseBotPackPythonIfAvailable(newValue);
         });
 
         update();

--- a/src/dk/aau/cs/ds306e18/tournament/ui/layout/RLBotSettingsTab.fxml
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/layout/RLBotSettingsTab.fxml
@@ -126,6 +126,23 @@
                         <RadioButton fx:id="writeOverlayDataRadioButton" layoutX="494.0" layoutY="13.0" mnemonicParsing="false" GridPane.columnIndex="1" />
                      </children>
                   </GridPane>
+                  <GridPane layoutX="30.0" layoutY="324.0">
+                     <columnConstraints>
+                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+                        <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" minWidth="10.0" />
+                     </columnConstraints>
+                     <rowConstraints>
+                        <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+                     </rowConstraints>
+                     <children>
+                        <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Use the RLBotPack's Python installation if available">
+                           <font>
+                              <Font size="16.0" />
+                           </font>
+                        </Text>
+                        <RadioButton fx:id="useRLBotPackPythonRadioButton" layoutX="494.0" layoutY="13.0" mnemonicParsing="false" GridPane.columnIndex="1" />
+                     </children>
+                  </GridPane>
                   <Separator layoutX="30.0" layoutY="279.0" prefWidth="200.0" />
                   <Text layoutX="30.0" layoutY="309.0" strokeType="OUTSIDE" strokeWidth="0.0" text="RLBot Runner">
                      <font>


### PR DESCRIPTION
The RLBotPack has its own Python environment with everything bots need, and the local installation is not guaranteed to have all the required packages. Therefore, we should use RLBotPack's Python installation. The user can toggle behaviour in the settings tab.

Depends on #97 