### PR TITLE
Store latest paths to make file choosers start in more convenient directories

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+#### Version 1.7.2
+- CleoPetra is now way smarter about where file choosers starts. - NicEastvillage
+
+#### Version 1.7.1
+- Fixed bug that prevented overlay to be written to current_match.json. - NicEastvillage
+- Fixed bug where overlay path text field was not updated when loading a saved tournament. #103 - NicEastvillage
+
 #### Version 1.7 - 26. April 2020
 - Added option to use RLBotPack Python installation if available (default: true). - NicEastvillage
 - Added option for using random standard map. - Darxeal

--- a/src/dk/aau/cs/ds306e18/tournament/Main.java
+++ b/src/dk/aau/cs/ds306e18/tournament/Main.java
@@ -1,5 +1,6 @@
 package dk.aau.cs.ds306e18.tournament;
 
+import dk.aau.cs.ds306e18.tournament.settings.CleoPetraSettings;
 import dk.aau.cs.ds306e18.tournament.settings.SettingsDirectory;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
@@ -12,8 +13,6 @@ import java.io.File;
 
 
 public class Main extends Application {
-
-    public static File lastSavedDirectory = new File(System.getProperty("user.home"));
 
     @Override
     public void start(Stage primaryStage) throws Exception {
@@ -28,7 +27,7 @@ public class Main extends Application {
     }
 
     public static void main(String[] args) {
-        SettingsDirectory.setup();
+        CleoPetraSettings.setup();
         launch(args);
     }
 }

--- a/src/dk/aau/cs/ds306e18/tournament/settings/CleoPetraSettings.java
+++ b/src/dk/aau/cs/ds306e18/tournament/settings/CleoPetraSettings.java
@@ -1,0 +1,67 @@
+package dk.aau.cs.ds306e18.tournament.settings;
+
+import dk.aau.cs.ds306e18.tournament.Main;
+import dk.aau.cs.ds306e18.tournament.utility.FileOperations;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Properties;
+
+public class CleoPetraSettings {
+
+    private static Properties properties;
+    private static LatestPaths latestPaths;
+
+    /**
+     * Setup/load the settings for CleoPetra, located in 'user.home/.cleopetra/', and makes sure the required
+     * files are present. Should always be called on start up.
+     */
+    public static void setup() {
+        try {
+
+            Files.createDirectories(SettingsDirectory.BASE);
+
+            // CleoPetra properties
+            if (Files.notExists(SettingsDirectory.PROPERTIES)) {
+                Files.createFile(SettingsDirectory.PROPERTIES);
+            }
+            try (InputStream fs = Files.newInputStream(SettingsDirectory.PROPERTIES)) {
+                properties = new Properties();
+                properties.load(fs);
+            }
+
+            latestPaths = new LatestPaths(properties);
+
+            // Files for starting matches. 'rlbot.cfg' is created right before match start.
+            Files.createDirectories(SettingsDirectory.MATCH_FILES);
+            Files.copy(Main.class.getResourceAsStream("settings/files/run.py"), SettingsDirectory.RUN_PY, StandardCopyOption.REPLACE_EXISTING);
+
+            setupPsyonixBots();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Copies the Psyonix bot config files to the CleoPetra settings folder so they can be read by the RLBot framework.
+     * If the files already exists, they won't be replaced. This allows the user to change the config files
+     * (e.g. change the appearance) and customize their Psyonix bots.
+     *
+     * @throws IOException thrown if something goes wrong during copying the files or if URI path is wrong.
+     */
+    private static void setupPsyonixBots() throws IOException {
+        Files.createDirectories(SettingsDirectory.PSYONIX_BOTS);
+        FileOperations.copyIfMissing(Main.class.getResourceAsStream("settings/files/psyonix_appearance.cfg"), SettingsDirectory.PSYONIX_APPEARANCE);
+        FileOperations.copyIfMissing(Main.class.getResourceAsStream("settings/files/psyonix_allstar.cfg"), SettingsDirectory.PSYONIX_ALLSTAR);
+        FileOperations.copyIfMissing(Main.class.getResourceAsStream("settings/files/psyonix_pro.cfg"), SettingsDirectory.PSYONIX_PRO);
+        FileOperations.copyIfMissing(Main.class.getResourceAsStream("settings/files/psyonix_rookie.cfg"), SettingsDirectory.PSYONIX_ROOKIE);
+    }
+
+    public static LatestPaths getLatestPaths() {
+        return latestPaths;
+    }
+}

--- a/src/dk/aau/cs/ds306e18/tournament/settings/LatestPaths.java
+++ b/src/dk/aau/cs/ds306e18/tournament/settings/LatestPaths.java
@@ -33,7 +33,12 @@ public class LatestPaths {
      */
     public File getTournamentSaveDirectory() {
         String tournamentSaveDirectory = properties.getProperty(KEY_TOURNAMENT_SAVE_DIR);
-        if (tournamentSaveDirectory != null) return new File(tournamentSaveDirectory);
+        if (tournamentSaveDirectory != null) {
+            File dir = new File(tournamentSaveDirectory);
+            // Dir might not exist anymore. In that case we will forget about it
+            if (dir.exists()) return dir;
+            else properties.remove(KEY_TOURNAMENT_SAVE_DIR);
+        }
         return FALLBACK_DIR;
     }
 
@@ -41,8 +46,10 @@ public class LatestPaths {
      * Update latest tournament save directory.
      */
     public void setTournamentSaveDirectory(File dir) {
-        properties.setProperty(KEY_TOURNAMENT_SAVE_DIR, dir.getAbsolutePath());
-        saveProperties();
+        if (dir.exists()) {
+            properties.setProperty(KEY_TOURNAMENT_SAVE_DIR, dir.getAbsolutePath());
+            saveProperties();
+        }
     }
 
     /**
@@ -50,7 +57,12 @@ public class LatestPaths {
      */
     public File getBotConfigDirectory() {
         String botConfigDirectory = properties.getProperty(KEY_BOT_CONFIG_DIR);
-        if (botConfigDirectory != null) return new File(botConfigDirectory);
+        if (botConfigDirectory != null) {
+            File dir = new File(botConfigDirectory);
+            // Dir might not exist anymore. In that case we will forget about it
+            if (dir.exists()) return dir;
+            else properties.remove(KEY_BOT_CONFIG_DIR);
+        }
         // Fallback to tournament save dir
         return getTournamentSaveDirectory();
     }
@@ -59,8 +71,10 @@ public class LatestPaths {
      * Update latest bot config directory.
      */
     public void setBotConfigDirectory(File dir) {
-        properties.setProperty(KEY_BOT_CONFIG_DIR, dir.getAbsolutePath());
-        saveProperties();
+        if (dir.exists()) {
+            properties.setProperty(KEY_BOT_CONFIG_DIR, dir.getAbsolutePath());
+            saveProperties();
+        }
     }
 
     /**
@@ -68,7 +82,12 @@ public class LatestPaths {
      */
     public File getOverlayDirectory() {
         String overlayDirectory = properties.getProperty(KEY_OVERLAY_DIR);
-        if (overlayDirectory != null) return new File(overlayDirectory);
+        if (overlayDirectory != null) {
+            File dir = new File(overlayDirectory);
+            // Dir might not exist anymore. In that case we will forget about it
+            if (dir.exists()) return dir;
+            else properties.remove(KEY_TOURNAMENT_SAVE_DIR);
+        }
         // Fallback to tournament save dir
         return getTournamentSaveDirectory();
     }
@@ -77,8 +96,10 @@ public class LatestPaths {
      * Update latest overlay directory.
      */
     public void setOverlayDirectory(File dir) {
-        properties.setProperty(KEY_OVERLAY_DIR, dir.getAbsolutePath());
-        saveProperties();
+        if (dir.exists()) {
+            properties.setProperty(KEY_OVERLAY_DIR, dir.getAbsolutePath());
+            saveProperties();
+        }
     }
 
     private void saveProperties() {

--- a/src/dk/aau/cs/ds306e18/tournament/settings/LatestPaths.java
+++ b/src/dk/aau/cs/ds306e18/tournament/settings/LatestPaths.java
@@ -1,0 +1,91 @@
+package dk.aau.cs.ds306e18.tournament.settings;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.Properties;
+
+/**
+ * A helper class to handle paths to where tournament files, bots, and overlays are stored. Main usage is
+ * making file chooser start from a reasonable directory.
+ */
+public class LatestPaths {
+
+    // If we have no info about where things are stored we will use the current working directory
+    private static final File FALLBACK_DIR = new File("").getAbsoluteFile();
+
+    private static final String KEY_TOURNAMENT_SAVE_DIR = "lastTournamentSaveDir";
+    private static final String KEY_BOT_CONFIG_DIR = "lastBotConfigDir";
+    private static final String KEY_OVERLAY_DIR = "lastOverlayDir";
+
+    private final Properties properties;
+
+    /**
+     * Create a new LatestPaths based on the given properties file.
+     */
+    public LatestPaths(Properties properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * Returns the directory where the latest tournament file was saved or a reasonable fallback directory.
+     */
+    public File getTournamentSaveDirectory() {
+        String tournamentSaveDirectory = properties.getProperty(KEY_TOURNAMENT_SAVE_DIR);
+        if (tournamentSaveDirectory != null) return new File(tournamentSaveDirectory);
+        return FALLBACK_DIR;
+    }
+
+    /**
+     * Update latest tournament save directory.
+     */
+    public void setTournamentSaveDirectory(File dir) {
+        properties.setProperty(KEY_TOURNAMENT_SAVE_DIR, dir.getAbsolutePath());
+        saveProperties();
+    }
+
+    /**
+     * Returns the directory where the latest bot(s) was loaded from or a reasonable fallback directory.
+     */
+    public File getBotConfigDirectory() {
+        String botConfigDirectory = properties.getProperty(KEY_BOT_CONFIG_DIR);
+        if (botConfigDirectory != null) return new File(botConfigDirectory);
+        // Fallback to tournament save dir
+        return getTournamentSaveDirectory();
+    }
+
+    /**
+     * Update latest bot config directory.
+     */
+    public void setBotConfigDirectory(File dir) {
+        properties.setProperty(KEY_BOT_CONFIG_DIR, dir.getAbsolutePath());
+        saveProperties();
+    }
+
+    /**
+     * Returns the directory where the latest overlay was stored or a reasonable fallback directory.
+     */
+    public File getOverlayDirectory() {
+        String overlayDirectory = properties.getProperty(KEY_OVERLAY_DIR);
+        if (overlayDirectory != null) return new File(overlayDirectory);
+        // Fallback to tournament save dir
+        return getTournamentSaveDirectory();
+    }
+
+    /**
+     * Update latest overlay directory.
+     */
+    public void setOverlayDirectory(File dir) {
+        properties.setProperty(KEY_OVERLAY_DIR, dir.getAbsolutePath());
+        saveProperties();
+    }
+
+    private void saveProperties() {
+        try (OutputStream fs = Files.newOutputStream(SettingsDirectory.PROPERTIES)) {
+            properties.store(fs, null);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/dk/aau/cs/ds306e18/tournament/settings/SettingsDirectory.java
+++ b/src/dk/aau/cs/ds306e18/tournament/settings/SettingsDirectory.java
@@ -16,6 +16,7 @@ import java.nio.file.StandardCopyOption;
 public class SettingsDirectory {
 
     public static final Path BASE = Paths.get(System.getProperty("user.home")).resolve(".cleopetra/");
+    public static final Path PROPERTIES = BASE.resolve("cleopetra.properties");
     public static final Path PSYONIX_BOTS = BASE.resolve("psyonix_bots");
     public static final Path PSYONIX_APPEARANCE = PSYONIX_BOTS.resolve("psyonix_appearance.cfg");
     public static final Path PSYONIX_ALLSTAR = PSYONIX_BOTS.resolve("psyonix_allstar.cfg");
@@ -25,36 +26,4 @@ public class SettingsDirectory {
     public static final Path MATCH_CONFIG = MATCH_FILES.resolve("rlbot.cfg");
     public static final Path RUN_PY = MATCH_FILES.resolve("run.py");
 
-    /**
-     * Setup the settings directory, 'user.home/.cleopetra/', and makes sure the required files are present. Should
-     * always be called on start up.
-     */
-    public static void setup() {
-        try {
-
-            // Files for starting matches. 'rlbot.cfg' is created right before match start.
-            Files.createDirectories(MATCH_FILES);
-            Files.copy(Main.class.getResourceAsStream("settings/files/run.py"), RUN_PY, StandardCopyOption.REPLACE_EXISTING);
-
-            setupPsyonixBots();
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    /**
-     * Copies the Psyonix bot config files to the CleoPetra settings folder so they can be read by the RLBot framework.
-     * If the files already exists, they won't be replaced. This allows the user to change the config files
-     * (e.g. change the appearance) and customize their Psyonix bots.
-     *
-     * @throws IOException thrown if something goes wrong during copying the files or if URI path is wrong.
-     */
-    private static void setupPsyonixBots() throws IOException {
-        Files.createDirectories(PSYONIX_BOTS);
-        FileOperations.copyIfMissing(Main.class.getResourceAsStream("settings/files/psyonix_appearance.cfg"), PSYONIX_APPEARANCE);
-        FileOperations.copyIfMissing(Main.class.getResourceAsStream("settings/files/psyonix_allstar.cfg"), PSYONIX_ALLSTAR);
-        FileOperations.copyIfMissing(Main.class.getResourceAsStream("settings/files/psyonix_pro.cfg"), PSYONIX_PRO);
-        FileOperations.copyIfMissing(Main.class.getResourceAsStream("settings/files/psyonix_rookie.cfg"), PSYONIX_ROOKIE);
-    }
 }

--- a/src/dk/aau/cs/ds306e18/tournament/ui/LauncherController.java
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/LauncherController.java
@@ -2,6 +2,8 @@ package dk.aau.cs.ds306e18.tournament.ui;
 
 import dk.aau.cs.ds306e18.tournament.Main;
 import dk.aau.cs.ds306e18.tournament.model.Tournament;
+import dk.aau.cs.ds306e18.tournament.settings.CleoPetraSettings;
+import dk.aau.cs.ds306e18.tournament.settings.LatestPaths;
 import dk.aau.cs.ds306e18.tournament.utility.Alerts;
 import dk.aau.cs.ds306e18.tournament.utility.FileOperations;
 import dk.aau.cs.ds306e18.tournament.utility.SaveLoad;
@@ -100,7 +102,7 @@ public class LauncherController {
         FileChooser fileChooser = new FileChooser();
         fileChooser.setTitle("Open tournament file");
         fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("Tournament format (*." + extension + ")", "*." + extension));
-        fileChooser.setInitialDirectory(Main.lastSavedDirectory);
+        fileChooser.setInitialDirectory(CleoPetraSettings.getLatestPaths().getTournamentSaveDirectory());
 
         File file = fileChooser.showOpenDialog(getLauncherStage());
 

--- a/src/dk/aau/cs/ds306e18/tournament/ui/ParticipantSettingsTabController.java
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/ParticipantSettingsTabController.java
@@ -2,6 +2,8 @@ package dk.aau.cs.ds306e18.tournament.ui;
 
 import dk.aau.cs.ds306e18.tournament.Main;
 import dk.aau.cs.ds306e18.tournament.model.*;
+import dk.aau.cs.ds306e18.tournament.settings.CleoPetraSettings;
+import dk.aau.cs.ds306e18.tournament.settings.LatestPaths;
 import dk.aau.cs.ds306e18.tournament.utility.Alerts;
 import dk.aau.cs.ds306e18.tournament.rlbot.BotCollection;
 import dk.aau.cs.ds306e18.tournament.utility.AutoNaming;
@@ -376,7 +378,8 @@ public class ParticipantSettingsTabController {
     @FXML
     public void onActionLoadConfig(ActionEvent actionEvent) {
         // Open file chooser
-        botConfigFileChooser.setInitialDirectory(Main.lastSavedDirectory);
+        LatestPaths latestPaths = CleoPetraSettings.getLatestPaths();
+        botConfigFileChooser.setInitialDirectory(latestPaths.getBotConfigDirectory());
         Window window = loadConfigButton.getScene().getWindow();
         List<File> files = botConfigFileChooser.showOpenMultipleDialog(window);
 
@@ -397,14 +400,15 @@ public class ParticipantSettingsTabController {
             botCollectionListView.setItems(FXCollections.observableArrayList(BotCollection.global));
             botCollectionListView.refresh();
 
-            Main.lastSavedDirectory = files.get(0).getParentFile();
+            latestPaths.setBotConfigDirectory(files.get(0).getParentFile());
         }
     }
 
     @FXML
     public void onActionLoadFolder(ActionEvent actionEvent) {
         // Open directory chooser
-        botFolderChooser.setInitialDirectory(Main.lastSavedDirectory);
+        LatestPaths latestPaths = CleoPetraSettings.getLatestPaths();
+        botFolderChooser.setInitialDirectory(latestPaths.getBotConfigDirectory());
         Window window = loadFolderButton.getScene().getWindow();
         File folder = botFolderChooser.showDialog(window);
 
@@ -414,7 +418,7 @@ public class ParticipantSettingsTabController {
             botCollectionListView.setItems(FXCollections.observableArrayList(BotCollection.global));
             botCollectionListView.refresh();
 
-            Main.lastSavedDirectory = folder;
+            latestPaths.setBotConfigDirectory(folder);
         }
     }
 

--- a/src/dk/aau/cs/ds306e18/tournament/ui/RLBotSettingsTabController.java
+++ b/src/dk/aau/cs/ds306e18/tournament/ui/RLBotSettingsTabController.java
@@ -6,6 +6,8 @@ import dk.aau.cs.ds306e18.tournament.rlbot.MatchRunner;
 import dk.aau.cs.ds306e18.tournament.rlbot.RLBotSettings;
 import dk.aau.cs.ds306e18.tournament.rlbot.configuration.MatchConfig;
 import dk.aau.cs.ds306e18.tournament.rlbot.configuration.MatchConfigOptions.*;
+import dk.aau.cs.ds306e18.tournament.settings.CleoPetraSettings;
+import dk.aau.cs.ds306e18.tournament.settings.LatestPaths;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
@@ -179,9 +181,10 @@ public class RLBotSettingsTabController {
     }
 
     public void onActionChooseOverlayPath(ActionEvent actionEvent) {
+        LatestPaths latestPaths = CleoPetraSettings.getLatestPaths();
         DirectoryChooser dirChooser = new DirectoryChooser();
         dirChooser.setTitle("Choose overlay folder");
-        dirChooser.setInitialDirectory(Main.lastSavedDirectory);
+        dirChooser.setInitialDirectory(latestPaths.getOverlayDirectory());
         Window window = chooseOverlayPathButton.getScene().getWindow();
         File folder = dirChooser.showDialog(window);
 
@@ -189,6 +192,7 @@ public class RLBotSettingsTabController {
             String path = folder.toString();
             overlayPathTextField.setText(path);
             Tournament.get().getRlBotSettings().setOverlayPath(path);
+            latestPaths.setOverlayDirectory(folder);
         }
     }
 }

--- a/src/dk/aau/cs/ds306e18/tournament/utility/SaveLoad.java
+++ b/src/dk/aau/cs/ds306e18/tournament/utility/SaveLoad.java
@@ -2,6 +2,8 @@ package dk.aau.cs.ds306e18.tournament.utility;
 
 import dk.aau.cs.ds306e18.tournament.Main;
 import dk.aau.cs.ds306e18.tournament.model.Tournament;
+import dk.aau.cs.ds306e18.tournament.settings.CleoPetraSettings;
+import dk.aau.cs.ds306e18.tournament.settings.LatestPaths;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 
@@ -23,17 +25,17 @@ public class SaveLoad {
      * @throws IOException thrown if something goes wrong during saving.
      */
     public static void saveTournamentWithFileChooser(Stage fxstage) throws IOException {
+        LatestPaths latestPaths = CleoPetraSettings.getLatestPaths();
         FileChooser fileChooser = new FileChooser();
         fileChooser.setTitle("Choose file name and save destination");
         fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("Tournament format (*." + EXTENSION + ")", "*." + EXTENSION));
         fileChooser.setInitialFileName(Tournament.get().getName() + "." + EXTENSION);
-        fileChooser.setInitialDirectory(Main.lastSavedDirectory);
+        fileChooser.setInitialDirectory(latestPaths.getTournamentSaveDirectory());
 
         File file = fileChooser.showSaveDialog(fxstage);
 
         if (file != null) {
             saveTournament(Tournament.get(), file);
-            Main.lastSavedDirectory = file.getParentFile();
         }
     }
 
@@ -42,8 +44,8 @@ public class SaveLoad {
      * @throws IOException thrown if something goes wrong during loading.
      */
     public static void saveTournament(Tournament tournament, File file) throws IOException {
+        CleoPetraSettings.getLatestPaths().setTournamentSaveDirectory(file.getParentFile());
         Files.write(file.toPath(), serialize(tournament).getBytes());
-        Main.lastSavedDirectory = file.getParentFile();
     }
 
     /**
@@ -52,7 +54,11 @@ public class SaveLoad {
      * @throws IOException thrown if something goes wrong during loading.
      */
     public static Tournament loadTournament(File file) throws IOException {
-        Main.lastSavedDirectory = file.getParentFile();
-        return deserialize(new String(Files.readAllBytes(file.toPath())));
+        CleoPetraSettings.getLatestPaths().setTournamentSaveDirectory(file.getParentFile());
+        Tournament tournament = deserialize(new String(Files.readAllBytes(file.toPath())));
+        if (tournament.getRlBotSettings().writeOverlayDataEnabled()) {
+            CleoPetraSettings.getLatestPaths().setOverlayDirectory(new File(tournament.getRlBotSettings().getOverlayPath()));
+        }
+        return tournament;
     }
 }


### PR DESCRIPTION
Whenever we save or load a tournament/bot/overlay, it will not be stored in `.cleopetra/cleopetra.properties`. This makes our file chooser much nicer to use as they start in move convenient directories.