### PR TITLE
Fixed a bug where RR stats were not updated correctly due to deserialization error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+#### Version 1.7.2
+- Fixed a bug where round robin stats were not updated correctly due to deserialization error. - NicEastvillage
+
 #### Version 1.7 - 26. April 2020
 - Added option to use RLBotPack Python installation if available (default: true). - NicEastvillage
 - Added option for using random standard map. - Darxeal

--- a/src/dk/aau/cs/ds306e18/tournament/model/format/DoubleEliminationFormat.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/format/DoubleEliminationFormat.java
@@ -282,7 +282,7 @@ public class DoubleEliminationFormat implements Format, MatchPlayedListener {
     private void setupStatsTracking() {
         List<Series> allSeries = getAllSeries();
         for (Team team : teams) {
-            team.getStatsManager().trackMatches(this, allSeries);
+            team.getStatsManager().trackAllSeries(this, allSeries);
         }
     }
 

--- a/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinFormat.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/format/RoundRobinFormat.java
@@ -19,7 +19,7 @@ public class RoundRobinFormat implements Format, MatchPlayedListener {
     private StageStatus status = StageStatus.PENDING;
     private int defaultSeriesLength = 1;
     private ArrayList<Team> teams;
-    private ArrayList<Series> series;
+    transient private ArrayList<Series> series;
     private ArrayList<RoundRobinGroup> groups;
     private int numberOfGroups = 1;
 
@@ -268,7 +268,7 @@ public class RoundRobinFormat implements Format, MatchPlayedListener {
     private void setupStatsTracking() {
         List<Series> allSeries = getAllSeries();
         for (Team team : teams) {
-            team.getStatsManager().trackMatches(this, allSeries);
+            team.getStatsManager().trackAllSeries(this, allSeries);
         }
     }
 
@@ -392,7 +392,8 @@ public class RoundRobinFormat implements Format, MatchPlayedListener {
 
     @Override
     public void postDeserializationRepair() {
-        for (Series series : this.getAllSeries()) series.registerMatchPlayedListener(this);
+        series = extractMatchesFromGroups();
+        for (Series series : series) series.registerMatchPlayedListener(this);
         setupStatsTracking();
     }
 

--- a/src/dk/aau/cs/ds306e18/tournament/model/format/SingleEliminationFormat.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/format/SingleEliminationFormat.java
@@ -148,7 +148,7 @@ public class SingleEliminationFormat implements Format, MatchPlayedListener {
     private void setupStatsTracking() {
         List<Series> allSeries = getAllSeries();
         for (Team team : seededTeams) {
-            team.getStatsManager().trackMatches(this, allSeries);
+            team.getStatsManager().trackAllSeries(this, allSeries);
         }
     }
 

--- a/src/dk/aau/cs/ds306e18/tournament/model/format/SwissFormat.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/format/SwissFormat.java
@@ -171,7 +171,7 @@ public class SwissFormat implements Format, MatchChangeListener, MatchPlayedList
 
         // Track stats from the new matches
         for (Team team : teams) {
-            team.getStatsManager().trackMatches(this, createdSeries);
+            team.getStatsManager().trackAllSeries(this, createdSeries);
         }
 
         rounds.add(createdSeries);
@@ -378,7 +378,7 @@ public class SwissFormat implements Format, MatchChangeListener, MatchPlayedList
         teamPoints = createPointsMap(teams);
         for (Team team : teams) {
             calculateAndAssignTeamPoints(team);
-            team.getStatsManager().trackMatches(this, getAllSeries());
+            team.getStatsManager().trackAllSeries(this, getAllSeries());
         }
     }
 

--- a/src/dk/aau/cs/ds306e18/tournament/model/match/Series.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/match/Series.java
@@ -326,7 +326,7 @@ public final class Series {
     }
 
     /**
-     * Returns true when both Teams are known and ready, even if the Match has already been played.
+     * Returns true when both Teams are known and ready, even if the Series has already been played.
      */
     public boolean isReadyToPlay() {
         return teamOne != null && teamTwo != null;
@@ -334,8 +334,8 @@ public final class Series {
 
     public Team getWinner() {
         switch (getOutcome()) {
-            case UNKNOWN: throw new IllegalStateException("Match has not been played.");
-            case DRAW: throw new IllegalStateException("Match ended in draw.");
+            case UNKNOWN: throw new IllegalStateException("Series has not been played.");
+            case DRAW: throw new IllegalStateException("Series ended in draw.");
             case TEAM_ONE_WINS: return getTeamOne();
             case TEAM_TWO_WINS: return getTeamTwo();
         }
@@ -344,8 +344,8 @@ public final class Series {
 
     public Team getLoser() {
         switch (getOutcome()) {
-            case UNKNOWN: throw new IllegalStateException("Match has not been played.");
-            case DRAW: throw new IllegalStateException("Match ended in draw.");
+            case UNKNOWN: throw new IllegalStateException("Series has not been played.");
+            case DRAW: throw new IllegalStateException("Series ended in draw.");
             case TEAM_ONE_WINS: return getTeamTwo();
             case TEAM_TWO_WINS: return getTeamOne();
         }

--- a/src/dk/aau/cs/ds306e18/tournament/model/stats/StatsManager.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/stats/StatsManager.java
@@ -9,7 +9,7 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 
 /**
- * Class for track all stats for a Team for individual Stages and globally across all Stages.
+ * Class for tracking all stats for a Team for individual Stages and globally across all Stages.
  */
 public class StatsManager implements StatsChangeListener {
 
@@ -42,34 +42,34 @@ public class StatsManager implements StatsChangeListener {
     }
 
     /**
-     * Start tracking stats from the given match.
+     * Start tracking stats from the given series.
      */
-    public void trackMatch(Format format, Series series) {
-        getTracker(format).trackMatch(series);
+    public void trackSeries(Format format, Series series) {
+        getTracker(format).trackSeries(series);
         recalculateGlobalStats();
     }
 
     /**
-     * Stop tracking stats from the given match.
+     * Stop tracking stats from the given series.
      */
-    public void untrackMatch(Format format, Series series) {
-        getTracker(format).untrackMatch(series);
+    public void untrackSeries(Format format, Series series) {
+        getTracker(format).untrackSeries(series);
         recalculateGlobalStats();
     }
 
     /**
-     * Start tracking stats from the given matches.
+     * Start tracking stats from the given series.
      */
-    public void trackMatches(Format format, Collection<? extends Series> matches) {
-        getTracker(format).trackMatches(matches);
+    public void trackAllSeries(Format format, Collection<? extends Series> matches) {
+        getTracker(format).trackAllSeries(matches);
         recalculateGlobalStats();
     }
 
     /**
-     * Stop tracking stats from the given matches.
+     * Stop tracking stats from the given series.
      */
-    public void untrackMatches(Format format, Collection<? extends Series> matches) {
-        getTracker(format).untrackMatches(matches);
+    public void untrackAllSeries(Format format, Collection<? extends Series> matches) {
+        getTracker(format).untrackAllSeries(matches);
         recalculateGlobalStats();
     }
 

--- a/src/dk/aau/cs/ds306e18/tournament/model/stats/StatsTracker.java
+++ b/src/dk/aau/cs/ds306e18/tournament/model/stats/StatsTracker.java
@@ -9,7 +9,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * This class tracks the stats (wins, loses, goals, etc) for a single team over a set of matches. The class uses the
+ * This class tracks the stats (wins, loses, goals, etc) for a single team over a set of series. The class uses the
  * MatchChangeListener interface to get updates about new stats.
  */
 class StatsTracker implements MatchChangeListener {
@@ -28,7 +28,7 @@ class StatsTracker implements MatchChangeListener {
     }
 
     /**
-     * Recalculates the stats by check each tracked match. StatsChangeListeners are notified afterwards.
+     * Recalculates the stats by check each tracked series. StatsChangeListeners are notified afterwards.
      */
     public void recalculate() {
         int wins = 0;
@@ -36,7 +36,7 @@ class StatsTracker implements MatchChangeListener {
         int goals = 0;
         int goalsConceded = 0;
         for (Series series : trackedSeries) {
-            // If the team is in the match, add the relevant stats
+            // If the team is in the series, add the relevant stats
             if (series.getTeamOne() == team) {
                 goals += series.getTeamOneScores().stream().mapToInt(x -> x.orElse(0)).sum();
                 goalsConceded += series.getTeamTwoScores().stream().mapToInt(x -> x.orElse(0)).sum();
@@ -63,7 +63,7 @@ class StatsTracker implements MatchChangeListener {
     }
 
     /**
-     * Returns a set of all the tracked matches. Changes to the set does not affect the Stats.
+     * Returns a set of all the tracked series. Changes to the set does not affect the Stats.
      */
     public Set<Series> getTrackedSeries() {
         return new HashSet<>(trackedSeries);
@@ -78,31 +78,31 @@ class StatsTracker implements MatchChangeListener {
     }
 
     /**
-     * Starts tracking stats from the given match. The associated team does not need to be a participant of the
-     * given match. StatsChangeListeners are notified.
-     * @param series a match to track stats from
+     * Starts tracking stats from the given series. The associated team does not need to be a participant of the
+     * given series. StatsChangeListeners are notified.
+     * @param series a series to track stats from
      */
-    public void trackMatch(Series series) {
+    public void trackSeries(Series series) {
         trackedSeries.add(series);
         series.registerMatchChangeListener(this);
         recalculate();
     }
     /**
-     * Stops tracking stats from the given match. StatsChangeListeners are notified.
-     * @param series a match to stop tracking stats from
+     * Stops tracking stats from the given series. StatsChangeListeners are notified.
+     * @param series a series to stop tracking stats from
      */
-    public void untrackMatch(Series series) {
+    public void untrackSeries(Series series) {
         trackedSeries.remove(series);
         series.unregisterMatchChangeListener(this);
         recalculate();
     }
 
     /**
-     * Starts tracking stats from the given matches. The associated team does not need to be a participant of the
+     * Starts tracking stats from the given series. The associated team does not need to be a participant of the
      * given matches. StatsChangeListeners are notified.
-     * @param matches a collection of matches to track stats from.
+     * @param matches a collection of series to track stats from.
      */
-    public void trackMatches(Collection<? extends Series> matches) {
+    public void trackAllSeries(Collection<? extends Series> matches) {
         for (Series series : matches) {
             trackedSeries.add(series);
             series.registerMatchChangeListener(this);
@@ -111,10 +111,10 @@ class StatsTracker implements MatchChangeListener {
     }
 
     /**
-     * Stops tracking stats from the given match. StatsChangeListeners are notified.
-     * @param matches a collection of matches to stop tracking stats from.
+     * Stops tracking stats from the given series. StatsChangeListeners are notified.
+     * @param matches a collection of series to stop tracking stats from.
      */
-    public void untrackMatches(Collection<? extends Series> matches) {
+    public void untrackAllSeries(Collection<? extends Series> matches) {
         for (Series series : matches) {
             trackedSeries.remove(series);
             series.unregisterMatchChangeListener(this);

--- a/test/dk/aau/cs/ds306e18/tournament/model/TieBreakerTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/TieBreakerTest.java
@@ -30,7 +30,7 @@ public class TieBreakerTest {
         seriesThree.setHasBeenPlayed(true);
 
         for (Team team : teams) {
-            team.getStatsManager().trackMatches(null, series);
+            team.getStatsManager().trackAllSeries(null, series);
         }
 
         List<Team> ordered = TieBreaker.GOAL_DIFF.compareAll(teams, null);
@@ -56,7 +56,7 @@ public class TieBreakerTest {
         seriesTwo.setHasBeenPlayed(true);
 
         for (Team team : teams) {
-            team.getStatsManager().trackMatches(null, series);
+            team.getStatsManager().trackAllSeries(null, series);
         }
 
         List<Team> ordered = TieBreaker.GOALS_SCORED.compareAll(teams, null);
@@ -81,7 +81,7 @@ public class TieBreakerTest {
         seriesTwo.setHasBeenPlayed(true);
 
         for (Team team : teams) {
-            team.getStatsManager().trackMatches(null, series);
+            team.getStatsManager().trackAllSeries(null, series);
         }
 
         List<Team> ordered = TieBreaker.SEED.compareAll(teams, null);
@@ -108,7 +108,7 @@ public class TieBreakerTest {
         seriesThree.setHasBeenPlayed(true);
 
         for (Team team : teams) {
-            team.getStatsManager().trackMatches(null, series);
+            team.getStatsManager().trackAllSeries(null, series);
         }
 
         // Team 0 and team 3 both have 2 goals, but team 0 has one point
@@ -149,7 +149,7 @@ public class TieBreakerTest {
         seriesThree.setHasBeenPlayed(true);
 
         for (Team team : teams) {
-            team.getStatsManager().trackMatches(null, series);
+            team.getStatsManager().trackAllSeries(null, series);
         }
 
         // Teams with points should be ahead, but their goals decide the order next

--- a/test/dk/aau/cs/ds306e18/tournament/model/stats/StatsTest.java
+++ b/test/dk/aau/cs/ds306e18/tournament/model/stats/StatsTest.java
@@ -25,7 +25,7 @@ public class StatsTest {
         assertEquals(0, statsA.getGoalsConceded());
 
         Series series = new Series(teamA, teamB);
-        teamA.getStatsManager().trackMatch(null, series);
+        teamA.getStatsManager().trackSeries(null, series);
         series.setScores(3, 2, 0);
         series.setHasBeenPlayed(true);
 
@@ -41,8 +41,8 @@ public class StatsTest {
         Team teamA = new Team("A", null, 0, "a");
         Team teamB = new Team("B", null, 0, "b");
         Series series = new Series(teamA, teamB);
-        teamA.getStatsManager().trackMatch(null, series);
-        teamB.getStatsManager().trackMatch(null, series);
+        teamA.getStatsManager().trackSeries(null, series);
+        teamB.getStatsManager().trackSeries(null, series);
 
         series.setScores(1, 3, 0); // Match not over
 
@@ -55,8 +55,8 @@ public class StatsTest {
         Team teamA = new Team("A", null, 0, "a");
         Team teamB = new Team("B", null, 0, "b");
         Series series = new Series(teamA, teamB);
-        teamA.getStatsManager().trackMatch(null, series);
-        teamB.getStatsManager().trackMatch(null, series);
+        teamA.getStatsManager().trackSeries(null, series);
+        teamB.getStatsManager().trackSeries(null, series);
 
         series.setScores(5, 2, 0);
         series.setHasBeenPlayed(true);
@@ -79,8 +79,8 @@ public class StatsTest {
         seriesTwo.setHasBeenPlayed(true);
 
         for (Team team : new Team[]{teamA, teamB, teamC}) {
-            team.getStatsManager().trackMatch(null, seriesOne);
-            team.getStatsManager().trackMatch(null, seriesTwo);
+            team.getStatsManager().trackSeries(null, seriesOne);
+            team.getStatsManager().trackSeries(null, seriesTwo);
         }
 
         assertStats(teamA, null, 1, 1, 5, 5);


### PR DESCRIPTION
Both series in `RoundRobinFormat::series` and `RoundRobinGroup::rounds` are saved. We only need to save them per group.