### PR TITLE
Add functionality to create team for each bot in collection.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
 #### Unreleased changes
-- Fixed bug that would prevent overlay data to be written on match start. - NicEastvillage
+- Add functionality to create a team for each bot in the bot collection. #114 - NicEastvillage
 - Change radio buttons to checkboxes in RLBot settings tab. - NicEastvillage
+- Fixed bug that would prevent overlay data to be written on match start. - NicEastvillage
 
 #### Version 1.7.5 - January 2021
 - Updated expected bot pack path and only load bot pack on request from user. - NicEastvillage

--- a/src/main/java/dk/aau/cs/ds306e18/tournament/ui/CreateTeamsWithEachBotController.java
+++ b/src/main/java/dk/aau/cs/ds306e18/tournament/ui/CreateTeamsWithEachBotController.java
@@ -1,0 +1,62 @@
+package dk.aau.cs.ds306e18.tournament.ui;
+
+import dk.aau.cs.ds306e18.tournament.model.Bot;
+import dk.aau.cs.ds306e18.tournament.model.Team;
+import dk.aau.cs.ds306e18.tournament.model.Tournament;
+import dk.aau.cs.ds306e18.tournament.rlbot.BotCollection;
+import javafx.application.Platform;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.control.Button;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.input.MouseEvent;
+import javafx.stage.Stage;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class CreateTeamsWithEachBotController extends DraggablePopupWindow {
+
+    @FXML private Button saveButton;
+    @FXML private Spinner<Integer> teamSizeSpinner;
+
+    @FXML
+    private void initialize() {
+        // Setup team size spinner
+        teamSizeSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(1, 32, 1));
+    }
+
+    public void closeWindow() {
+        Stage window = (Stage) teamSizeSpinner.getScene().getWindow();
+        window.close();
+    }
+
+    public void onCancelBtnPressed(ActionEvent actionEvent) {
+        closeWindow();
+    }
+
+    public void onSaveBtnPressed(ActionEvent actionEvent) {
+        Tournament tournament = Tournament.get();
+        int seed = tournament.getTeams().size();
+        int teamSize = teamSizeSpinner.getValue();
+        for (Bot bot : BotCollection.global) {
+            Team team = new Team(bot.getName(), Collections.nCopies(teamSize, bot), ++seed, "");
+            tournament.addTeam(team);
+        }
+        closeWindow();
+        Platform.runLater(ParticipantSettingsTabController.instance::update);
+    }
+
+    @FXML
+    public void windowDragged(MouseEvent mouseEvent) {
+        super.windowDragged(mouseEvent);
+    }
+
+    @FXML
+    public void windowPressed(MouseEvent mouseEvent) {
+        super.windowPressed(mouseEvent);
+    }
+}

--- a/src/main/java/dk/aau/cs/ds306e18/tournament/ui/ParticipantSettingsTabController.java
+++ b/src/main/java/dk/aau/cs/ds306e18/tournament/ui/ParticipantSettingsTabController.java
@@ -11,15 +11,18 @@ import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
-import javafx.stage.DirectoryChooser;
-import javafx.stage.FileChooser;
-import javafx.stage.Window;
+import javafx.stage.*;
+import javafx.stage.Stage;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -48,6 +51,7 @@ public class ParticipantSettingsTabController {
     @FXML private Button loadFolderButton;
     @FXML private Button loadBotPack;
     @FXML private ListView<Bot> botCollectionListView;
+    @FXML private Button createTeamWithEachBotButton;
 
     private FileChooser botConfigFileChooser;
     private DirectoryChooser botFolderChooser;
@@ -129,6 +133,7 @@ public class ParticipantSettingsTabController {
 
     /** Updates all ui elements */
     public void update() {
+        teamsListView.setItems(FXCollections.observableArrayList(Tournament.get().getTeams()));
         teamsListView.refresh();
         rosterListView.refresh();
         botCollectionListView.refresh();
@@ -436,5 +441,35 @@ public class ParticipantSettingsTabController {
         AutoNaming.autoName(team, Tournament.get().getTeams());
         updateTeamFields();
         teamsListView.refresh();
+    }
+
+    public void onActionCreateTeamWithEachBot(ActionEvent actionEvent) {
+        try {
+            javafx.stage.Stage createTeamsStage = new javafx.stage.Stage();
+            createTeamsStage.initStyle(StageStyle.TRANSPARENT);
+            createTeamsStage.initModality(Modality.APPLICATION_MODAL);
+
+            FXMLLoader loader = new FXMLLoader(ParticipantSettingsTabController.class.getResource("layout/CreateTeamsWithEachBot.fxml"));
+            AnchorPane createTeamsStageRoot = loader.load();
+            createTeamsStage.setScene(new Scene(createTeamsStageRoot));
+
+            // Calculate the center position of the main window.
+            javafx.stage.Stage mainWindow = (Stage) participantSettingsTab.getScene().getWindow();
+            double centerXPosition = mainWindow.getX() + mainWindow.getWidth()/2d;
+            double centerYPosition = mainWindow.getY() + mainWindow.getHeight()/2d;
+
+            // Assign popup window to the center of the main window.
+            createTeamsStage.setOnShown(ev -> {
+                createTeamsStage.setX(centerXPosition - createTeamsStage.getWidth()/2d);
+                createTeamsStage.setY(centerYPosition - createTeamsStage.getHeight()/2d);
+
+                createTeamsStage.show();
+            });
+
+            createTeamsStage.show();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/dk/aau/cs/ds306e18/tournament/ui/layout/CreateTeamsWithEachBot.fxml
+++ b/src/main/java/dk/aau/cs/ds306e18/tournament/ui/layout/CreateTeamsWithEachBot.fxml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.Cursor?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Spinner?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.text.Font?>
+<?import javafx.scene.text.Text?>
+
+<AnchorPane id="exitPopup" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" onMouseDragged="#windowDragged" onMousePressed="#windowPressed" stylesheets="@css/stylesheet.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dk.aau.cs.ds306e18.tournament.ui.CreateTeamsWithEachBotController">
+   <children>
+      <VBox alignment="CENTER">
+         <children>
+            <HBox alignment="TOP_RIGHT">
+               <children>
+                  <Button mnemonicParsing="false" onAction="#onCancelBtnPressed" styleClass="cancelBtn" text="X">
+                     <font>
+                        <Font name="System Bold" size="13.0" />
+                     </font>
+                     <opaqueInsets>
+                        <Insets />
+                     </opaqueInsets>
+                     <HBox.margin>
+                        <Insets bottom="1.0" left="1.0" right="1.0" top="1.0" />
+                     </HBox.margin>
+                     <cursor>
+                        <Cursor fx:constant="HAND" />
+                     </cursor>
+                  </Button>
+               </children>
+               <VBox.margin>
+                  <Insets />
+               </VBox.margin>
+            </HBox>
+            <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Create team with each bot in bot collection">
+               <font>
+                  <Font size="16.0" />
+               </font>
+               <VBox.margin>
+                  <Insets bottom="32.0" />
+               </VBox.margin>
+            </Text>
+            <GridPane hgap="8.0" prefWidth="257.0">
+               <columnConstraints>
+                  <ColumnConstraints hgrow="SOMETIMES" maxWidth="218.0" minWidth="10.0" prefWidth="198.0" />
+                  <ColumnConstraints hgrow="SOMETIMES" maxWidth="155.0" minWidth="10.0" prefWidth="71.0" />
+               </columnConstraints>
+               <rowConstraints>
+                  <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+               </rowConstraints>
+               <children>
+                  <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Team size:">
+                     <font>
+                        <Font size="16.0" />
+                     </font>
+                  </Text>
+                  <Spinner fx:id="teamSizeSpinner" GridPane.columnIndex="1" />
+               </children>
+               <VBox.margin>
+                  <Insets left="64.0" right="64.0" />
+               </VBox.margin>
+            </GridPane>
+            <HBox>
+               <children>
+                  <Pane minWidth="46.0" prefHeight="27.0" prefWidth="228.0" HBox.hgrow="ALWAYS" />
+                  <Button fx:id="saveButton" minWidth="65.0" mnemonicParsing="false" onAction="#onSaveBtnPressed" text="Create teams">
+                     <HBox.margin>
+                        <Insets right="8.0" />
+                     </HBox.margin>
+                  </Button>
+                  <Button minWidth="65.0" mnemonicParsing="false" onAction="#onCancelBtnPressed" text="Cancel" />
+               </children>
+               <padding>
+                  <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
+               </padding>
+               <VBox.margin>
+                  <Insets top="32.0" />
+               </VBox.margin>
+            </HBox>
+         </children>
+      </VBox>
+   </children>
+</AnchorPane>

--- a/src/main/java/dk/aau/cs/ds306e18/tournament/ui/layout/ParticipantSettingsTab.fxml
+++ b/src/main/java/dk/aau/cs/ds306e18/tournament/ui/layout/ParticipantSettingsTab.fxml
@@ -15,7 +15,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<HBox fx:id="participantSettingsTab" stylesheets="@css/stylesheet.css" xmlns="http://javafx.com/javafx/1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dk.aau.cs.ds306e18.tournament.ui.ParticipantSettingsTabController">
+<HBox fx:id="participantSettingsTab" stylesheets="@css/stylesheet.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dk.aau.cs.ds306e18.tournament.ui.ParticipantSettingsTabController">
    <children>
       <Pane minHeight="0.0" minWidth="0.0" prefHeight="0.0" prefWidth="0.0" HBox.hgrow="ALWAYS" />
       <VBox id="PS-leftside" maxWidth="360.0" minWidth="360.0" prefWidth="360.0" spacing="10.0">
@@ -190,6 +190,11 @@
                   <Insets />
                </opaqueInsets>
             </ListView>
+            <VBox alignment="TOP_RIGHT">
+               <children>
+                  <Button fx:id="createTeamWithEachBotButton" mnemonicParsing="false" onAction="#onActionCreateTeamWithEachBot" prefHeight="27.0" text="Create team with each bot" />
+               </children>
+            </VBox>
          </children>
       </VBox>
       <Pane layoutX="10.0" layoutY="10.0" minHeight="0.0" minWidth="0.0" prefHeight="0.0" prefWidth="0.0" HBox.hgrow="ALWAYS" />


### PR DESCRIPTION
Add button to Participant Settings tab that allows the user to create teams for each bot in the bot collection. When clicked, the user will be prompted about the team size (i.e. the number of copies of the particular bot the team should have).

Resolves #114 